### PR TITLE
Add serialize_completion for openai responses

### DIFF
--- a/autoblocks/_impl/vendor/openai/util.py
+++ b/autoblocks/_impl/vendor/openai/util.py
@@ -1,0 +1,13 @@
+import json
+
+
+def serialize_completion(completion):
+    # openai v0 returns a dictionary and openai v1 returns a ChatCompletion or Completion
+    # pydantic BaseModel
+    if hasattr(completion, "model_dump_json") and callable(completion.model_dump_json):
+        # Pydantic v2
+        return json.loads(completion.model_dump_json())
+    elif hasattr(completion, "json") and callable(completion.json):
+        # Pydantic v1
+        return json.loads(completion.json())
+    return completion

--- a/autoblocks/vendor/openai.py
+++ b/autoblocks/vendor/openai.py
@@ -1,1 +1,2 @@
 from autoblocks._impl.vendor.openai.patch import trace_openai  # noqa: F401
+from autoblocks._impl.vendor.openai.util import serialize_completion  # noqa: F401


### PR DESCRIPTION
Exposes a utility for serializing openai responses (they switched from dictionaries to pydantic models in v1)