### PR TITLE
Fix renovate dep type

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,7 @@
     {
       "groupName": "all non-major dev dependencies",
       "groupSlug": "all-minor-patch-dev",
-      "matchDepTypes": ["dev-dependencies"],
+      "matchDepTypes": ["dev"],
       "matchPackagePatterns": ["*"],
       "matchUpdateTypes": ["minor", "patch"]
     }


### PR DESCRIPTION
The depType for dev dependencies ends up being "dev" instead of "dev-dependencies" due to the way renovate parses the pyproject.toml file. If you search for "depType" in https://developer.mend.io/github/autoblocksai/python-sdk/-/job/018c3a7e-6751-7c43-8852-b72bc5c4acd6, you can see e.g.:

```
          {
            "changelogUrl": "https://docs.pytest.org/en/stable/changelog.html",
            "currentValue": "^7.4.0",
            "currentVersion": "7.4.3",
            "datasource": "pypi",
            "depName": "pytest",
            "depType": "dev",
            "fixedVersion": "7.4.3",
            "homepage": "https://docs.pytest.org/en/latest/",
            "lockedVersion": "7.4.3",
            "managerData": {
              "nestedVersion": false
            },
            "packageName": "pytest",
            "registryUrl": "https://pypi.org/pypi",
            "sourceUrl": "https://github.com/pytest-dev/pytest",
            "versioning": "poetry",
            "warnings": [],
            "updates": []
          },
```

`dev-dependencies` only works for old versions of poetry where deps would be under `tool.poetry.dependencies` or `tool.poetry.dev-dependencies`, but now dev deps are under `tool.poetry.group.dev.dependencies`

https://docs.renovatebot.com/modules/manager/poetry/#additional-information

https://python-poetry.org/docs/managing-dependencies/#dependency-groups

![Screenshot 2023-12-05 at 2 01 35 PM](https://github.com/autoblocksai/python-sdk/assets/7498009/f0d99904-5370-4b3a-b890-f63a36f7be19)

