### PR TITLE
Send tracer events to cli in test mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     strategy:
       fail-fast: false

--- a/autoblocks/_impl/context_vars.py
+++ b/autoblocks/_impl/context_vars.py
@@ -1,0 +1,7 @@
+from contextvars import ContextVar
+from typing import Optional
+
+current_external_test_id: ContextVar[Optional[str]] = ContextVar(
+    "autoblocks_sdk_current_external_test_id", default=None
+)
+current_test_case_hash: ContextVar[Optional[str]] = ContextVar("autoblocks_sdk_current_test_case_hash", default=None)

--- a/autoblocks/_impl/global_state.py
+++ b/autoblocks/_impl/global_state.py
@@ -8,6 +8,7 @@ import httpx
 log = logging.getLogger(__name__)
 
 _client: Optional[httpx.AsyncClient] = None
+_sync_client: Optional[httpx.Client] = None
 _loop: Optional[asyncio.AbstractEventLoop] = None
 _started: bool = False
 
@@ -19,6 +20,8 @@ def init() -> None:
         return
 
     _client = httpx.AsyncClient()
+
+    _sync_client = httpx.Client()
 
     _loop = asyncio.new_event_loop()
 
@@ -46,3 +49,9 @@ def http_client() -> httpx.AsyncClient:
     if not _client:
         raise Exception("HTTP client not initialized")
     return _client
+
+
+def sync_http_client() -> httpx.Client:
+    if not _sync_client:
+        raise Exception("HTTP client not initialized")
+    return _sync_client

--- a/autoblocks/_impl/testing/run.py
+++ b/autoblocks/_impl/testing/run.py
@@ -128,7 +128,6 @@ async def run_test_case_unsafe(
     Its caller will catch and handle all exceptions.
     """
     async with test_case_semaphore_registry[test_id]:
-
         if inspect.iscoroutinefunction(fn):
             output = await fn(test_case)
         else:
@@ -239,6 +238,7 @@ async def async_run_test_suite(
     }
 
     await global_state.http_client().post(f"{cli()}/start", json=dict(testExternalId=test_id))
+
     token = current_external_test_id.set(test_id)
     try:
         await all_settled(

--- a/autoblocks/_impl/testing/run.py
+++ b/autoblocks/_impl/testing/run.py
@@ -238,9 +238,8 @@ async def async_run_test_suite(
         evaluator.id: asyncio.Semaphore(evaluator.max_concurrency) for evaluator in evaluators
     }
 
-    token = current_external_test_id.set(test_id)
     await global_state.http_client().post(f"{cli()}/start", json=dict(testExternalId=test_id))
-
+    token = current_external_test_id.set(test_id)
     try:
         await all_settled(
             [

--- a/autoblocks/_impl/testing/run.py
+++ b/autoblocks/_impl/testing/run.py
@@ -134,7 +134,6 @@ async def run_test_case_unsafe(
             output = await fn(test_case)
         else:
             ctx = contextvars.copy_context()
-            print(ctx.items())
             output = await global_state.event_loop().run_in_executor(None, ctx.run, fn, test_case)
 
     await global_state.http_client().post(

--- a/autoblocks/_impl/tracer.py
+++ b/autoblocks/_impl/tracer.py
@@ -270,7 +270,7 @@ class AutoblocksTracer:
         )
         req.raise_for_status()
 
-    def merge_properties(
+    def _merge_properties(
         self,
         *,
         span_id: Optional[str] = None,
@@ -311,7 +311,7 @@ class AutoblocksTracer:
         the event failed, the trace_id will be None.
         """
         try:
-            merged_properties = self.merge_properties(
+            merged_properties = self._merge_properties(
                 span_id=span_id, parent_span_id=parent_span_id, properties=properties, prompt_tracking=prompt_tracking
             )
             trace_id = trace_id or self._trace_id

--- a/autoblocks/_impl/tracer.py
+++ b/autoblocks/_impl/tracer.py
@@ -323,7 +323,7 @@ class AutoblocksTracer:
                     properties=merged_properties,
                     evaluators=evaluators,
                 ),
-                asyncio.get_event_loop(),
+                global_state.event_loop(),
             )
             future.result()  # Block on result: Todo: make this not blocking
         except Exception as err:

--- a/autoblocks/_impl/tracer.py
+++ b/autoblocks/_impl/tracer.py
@@ -18,6 +18,8 @@ from typing import Union
 
 from autoblocks._impl import global_state
 from autoblocks._impl.config.constants import INGESTION_ENDPOINT
+from autoblocks._impl.context_vars import current_external_test_id
+from autoblocks._impl.context_vars import current_test_case_hash
 from autoblocks._impl.testing.models import BaseEventEvaluator
 from autoblocks._impl.testing.models import Evaluation
 from autoblocks._impl.testing.models import TracerEvent
@@ -60,6 +62,7 @@ class AutoblocksTracer:
 
         self._client_headers = {"Authorization": f"Bearer {ingestion_key}"}
         self._timeout_seconds = timeout.total_seconds()
+        self._cli_server_address = AutoblocksEnvVar.CLI_SERVER_ADDRESS.get()
 
     def set_trace_id(self, trace_id: str) -> None:
         """
@@ -191,27 +194,11 @@ class AutoblocksTracer:
         # Require all arguments to be specified via key=value
         *,
         message: str,
+        timestamp: str,
+        properties: Dict[Any, Any],
         trace_id: Optional[str],
-        span_id: Optional[str],
-        parent_span_id: Optional[str],
-        timestamp: Optional[str],
-        properties: Optional[Dict[Any, Any]],
         evaluators: Optional[List[BaseEventEvaluator]],
-        prompt_tracking: Optional[Dict[str, Any]],
     ) -> None:
-        merged_properties = dict(self._properties)
-        merged_properties.update(properties or {})
-
-        # Overwrite properties with any provided as top level arguments
-        if span_id:
-            merged_properties["span_id"] = span_id
-        if parent_span_id:
-            merged_properties["parent_span_id"] = parent_span_id
-        if prompt_tracking:
-            merged_properties["promptTracking"] = prompt_tracking
-        trace_id = trace_id or self._trace_id
-        timestamp = timestamp or datetime.now(timezone.utc).isoformat()
-
         # If there are evaluators, run them and compute the evaluations property
         if evaluators:
             try:
@@ -220,13 +207,13 @@ class AutoblocksTracer:
                         message=message,
                         trace_id=trace_id,
                         timestamp=timestamp,
-                        properties=merged_properties,
+                        properties=properties,
                     ),
                     evaluators=evaluators,
                 )
                 if evaluations:
                     # Update merged properties with computed evaluations property
-                    merged_properties["evaluations"] = evaluations
+                    properties["evaluations"] = evaluations
             except Exception as err:
                 log.error("Unable to evaluate events. Error: %s", err, exc_info=True)
 
@@ -234,12 +221,51 @@ class AutoblocksTracer:
             message=message,
             trace_id=trace_id,
             timestamp=timestamp,
-            properties=merged_properties,
+            properties=properties,
         )
         req = await global_state.http_client().post(
             url=INGESTION_ENDPOINT,
             json=traced_event.to_json(),
             headers=self._client_headers,
+            timeout=self._timeout_seconds,
+        )
+        req.raise_for_status()
+
+    def _send_test_event_unsafe(
+        self,
+        # Require all arguments to be specified via key=value
+        *,
+        message: str,
+        timestamp: str,
+        properties: Dict[Any, Any],
+        trace_id: Optional[str],
+    ) -> None:
+        """Sends an event to the Autoblocks CLI in a testing environment."""
+        if not self._cli_server_address:
+            log.error("Failed to send test event to Autoblocks. CLI server address not set.")
+            return
+
+        if not current_external_test_id.get():
+            log.error("Failed to send test event to Autoblocks. No test ID set.")
+            return
+
+        if not current_test_case_hash.get():
+            log.error("Failed to send test event to Autoblocks. No test case hash set.")
+            return
+
+        traced_event = TracerEvent(
+            message=message,
+            trace_id=trace_id,
+            timestamp=timestamp,
+            properties=properties,
+        )
+        req = global_state.sync_http_client().post(
+            url=f"{self._cli_server_address}/events",
+            json=dict(
+                testExternalId=current_external_test_id.get(),
+                testCaseHash=current_test_case_hash.get(),
+                event=traced_event.to_json(),
+            ),
             timeout=self._timeout_seconds,
         )
         req.raise_for_status()
@@ -264,18 +290,40 @@ class AutoblocksTracer:
         the event failed, the trace_id will be None.
         """
         try:
+            merged_properties = dict(self._properties)
+            merged_properties.update(properties or {})
+
+            # Overwrite properties with any provided as top level arguments
+            if span_id:
+                merged_properties["span_id"] = span_id
+            if parent_span_id:
+                merged_properties["parent_span_id"] = parent_span_id
+            if prompt_tracking:
+                merged_properties["promptTracking"] = prompt_tracking
+            trace_id = trace_id or self._trace_id
+            timestamp = timestamp or datetime.now(timezone.utc).isoformat()
+
+            # If the CLI server address is set, we are in a test context and should send events to the CLI
+            # We also do not run evaluators in a test context
+            if self._cli_server_address:
+                self._send_test_event_unsafe(
+                    message=message,
+                    trace_id=trace_id,
+                    timestamp=timestamp,
+                    properties=merged_properties,
+                )
+                return
+
+            # Otherwise we are in a real context and should send events to the Autoblocks ingestion API
             future = asyncio.run_coroutine_threadsafe(
                 self._send_event_unsafe(
                     message=message,
                     trace_id=trace_id,
-                    span_id=span_id,
-                    parent_span_id=parent_span_id,
                     timestamp=timestamp,
-                    properties=properties,
+                    properties=merged_properties,
                     evaluators=evaluators,
-                    prompt_tracking=prompt_tracking,
                 ),
-                global_state.event_loop(),
+                asyncio.get_event_loop(),
             )
             future.result()  # Block on result: Todo: make this not blocking
         except Exception as err:

--- a/tests/autoblocks/test_run_test_suite.py
+++ b/tests/autoblocks/test_run_test_suite.py
@@ -1216,8 +1216,11 @@ def test_sends_tracer_events(httpx_mock):
         ),
     )
 
+    # initialize the tracer outside the test function
+    # this ensures the context variables are being access inside send_event
+    tracer = AutoblocksTracer("test")
+
     async def test_fn(test_case: MyTestCase):
-        tracer = AutoblocksTracer("test")
         if test_case.input == "a":
             # simulate doing more work than b to make sure context manager is working correctly
             await asyncio.sleep(1)

--- a/tests/autoblocks/test_run_test_suite.py
+++ b/tests/autoblocks/test_run_test_suite.py
@@ -764,8 +764,6 @@ def test_async_test_fn(httpx_mock):
     )
 
     async def test_fn(test_case: MyTestCase):
-        if test_case.input == "a":
-            await asyncio.sleep(5)
         return test_case.input + "!"
 
     run_test_suite(


### PR DESCRIPTION
Synchronously sends events to the cli when we detect a cli environment variable. The cli just collects these into an array, so doing this synchronously will have minimal impact on the test run.

Uses context variables to associate test id and test case hash. The test is setup so that it verifies when we have multiple test cases running at a time, everything is working correctly.