### PR TITLE
EPD-669 Support repeating test cases

### DIFF
--- a/autoblocks/_impl/prompts/context.py
+++ b/autoblocks/_impl/prompts/context.py
@@ -47,7 +47,6 @@ class PromptExecutionContext(abc.ABC, Generic[ParamsType, TemplateRendererType])
             self._prompt,
         )
 
-    @functools.lru_cache(1)
     def track(self) -> Dict[str, Any]:
         prompt = self._prompt.model_dump()
         prompt.pop("params", None)

--- a/autoblocks/_impl/testing/models.py
+++ b/autoblocks/_impl/testing/models.py
@@ -6,7 +6,7 @@ from typing import Dict
 from typing import Optional
 
 
-@dataclasses.dataclass()
+@dataclasses.dataclass
 class TracerEvent:
     message: str
     timestamp: str
@@ -22,7 +22,7 @@ class TracerEvent:
         }
 
 
-@dataclasses.dataclass()
+@dataclasses.dataclass
 class Threshold:
     lt: Optional[float] = None
     lte: Optional[float] = None
@@ -30,21 +30,52 @@ class Threshold:
     gte: Optional[float] = None
 
 
-@dataclasses.dataclass()
+@dataclasses.dataclass
 class Evaluation:
     score: float
     threshold: Optional[Threshold] = None
     metadata: Optional[Dict[str, Any]] = None
 
 
+@dataclasses.dataclass
+class TestCaseConfig:
+    repeat_num_times: Optional[int] = None
+
+
 class BaseTestCase(abc.ABC):
     @abc.abstractmethod
     def hash(self) -> str:
+        """
+        This hash is used to identify this test case throughout its lifetime.
+        """
         pass
+
+
+@dataclasses.dataclass
+class TestCaseContext:
+    """
+    This class serves as a container for the user's test case +
+    utilities around that test case.
+    """
+
+    # The user's test case
+    test_case: BaseTestCase
+
+    # Defined if the user has configured their test case to repeat
+    repetition_idx: Optional[int]
 
     @functools.cached_property
     def _cached_hash(self) -> str:
-        return self.hash()
+        return self.test_case.hash()
+
+    def hash(self) -> str:
+        if self.repetition_idx is not None:
+            # In the future, instead of modifying the hash, we should
+            # leave the hash as-is and instead pass the repetition idx
+            # in the /results request and make it a top level attribute
+            # in our data model.
+            return f"{self._cached_hash}-{self.repetition_idx}"
+        return self._cached_hash
 
 
 class BaseTestEvaluator(abc.ABC):

--- a/autoblocks/testing/models.py
+++ b/autoblocks/testing/models.py
@@ -2,5 +2,6 @@ from autoblocks._impl.testing.models import BaseEventEvaluator  # noqa: F401
 from autoblocks._impl.testing.models import BaseTestCase  # noqa: F401
 from autoblocks._impl.testing.models import BaseTestEvaluator  # noqa: F401
 from autoblocks._impl.testing.models import Evaluation  # noqa: F401
+from autoblocks._impl.testing.models import TestCaseConfig  # noqa: F401
 from autoblocks._impl.testing.models import Threshold  # noqa: F401
 from autoblocks._impl.testing.models import TracerEvent  # noqa: F401


### PR DESCRIPTION
i think for TS this will look roughly the same, we'll give you a `TestCaseConfig` type that you can make optional on your test case interface:

```ts
import type { TestCaseConfig } from '@autoblocks/client/testing';

interface MyTestCase {
  testCaseConfig?: TestCaseConfig;

  input: string;
}

const testCase: MyTestCase = {
  testCaseConfig: {
    repeatNumTimes: 3,
  },
  input: 'a',
};
```

or alternatively give you an interface that you can extend:

```ts
import type { BaseTestCase } from '@autoblocks/client/testing';

interface MyTestCase extends BaseTestCase {
  input: string;
}

const testCase: MyTestCase = {
  testCaseConfig: {
    repeatNumTimes: 3,
  },
  input: 'a',
};
```

the first is more consistent w/ how we're doing it here, but the way we're doing it here is kind of a workaround due to limitations in dataclass inheritance. i think the 2nd is more ideal