### PR TITLE
Make checking for test run context consistent with JS SDK

### DIFF
--- a/autoblocks/_impl/context_vars.py
+++ b/autoblocks/_impl/context_vars.py
@@ -10,5 +10,5 @@ class TestCaseRunContext:
 
 
 test_case_run_context_var: ContextVar[Optional[TestCaseRunContext]] = ContextVar(
-    "autoblocks_sdk_current_external_test_id", default=None
+    "autoblocks_sdk_test_case_run_context_var", default=None
 )

--- a/autoblocks/_impl/context_vars.py
+++ b/autoblocks/_impl/context_vars.py
@@ -1,7 +1,14 @@
+import dataclasses
 from contextvars import ContextVar
 from typing import Optional
 
-current_external_test_id: ContextVar[Optional[str]] = ContextVar(
+
+@dataclasses.dataclass
+class TestCaseRunContext:
+    test_id: str
+    test_case_hash: str
+
+
+test_case_run_context_var: ContextVar[Optional[TestCaseRunContext]] = ContextVar(
     "autoblocks_sdk_current_external_test_id", default=None
 )
-current_test_case_hash: ContextVar[Optional[str]] = ContextVar("autoblocks_sdk_current_test_case_hash", default=None)


### PR DESCRIPTION
This will make it so even if you are running through our cli, if you use send event outside of a test run events will still send. This will be consistent with - https://github.com/autoblocksai/javascript-sdk/pull/120