### PR TITLE
update types to pass mypy --strict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        entry: poetry run mypy --strict autoblocks
+        entry: poetry run mypy .
         language: system
         types: [python]
         pass_filenames: false

--- a/autoblocks/_impl/prompts/autogenerate.py
+++ b/autoblocks/_impl/prompts/autogenerate.py
@@ -154,6 +154,9 @@ def indent(times: int = 1, size: int = 4) -> str:
 
 def generate_params_class_code(prompt: Prompt) -> str:
     auto = f"class {prompt.params_class_name}(FrozenModel):\n"
+    if not prompt.params:
+        auto += f"{indent()}pass\n"
+        return auto
 
     for key, value in prompt.params.items():
         type_hint = infer_type(value)
@@ -215,22 +218,12 @@ def generate_template_renderer_class_code(prompt: Prompt) -> str:
 def generate_execution_context_class_code(prompt: Prompt) -> str:
     auto = f"class {prompt.execution_context_class_name}(\n"
     auto += f"{indent()}PromptExecutionContext[\n"
-    auto += f"{indent(2)}{prompt.params_class_name if prompt.params else 'None'},\n"
+    auto += f"{indent(2)}{prompt.params_class_name},\n"
     auto += f"{indent(2)}{prompt.template_renderer_class_name},\n"
     auto += f"{indent()}],\n"
     auto += "):\n"
-    auto += f"{indent()}__params_class__ = {prompt.params_class_name if prompt.params else 'None'}\n"
+    auto += f"{indent()}__params_class__ = {prompt.params_class_name}\n"
     auto += f"{indent()}__template_renderer_class__ = {prompt.template_renderer_class_name}\n"
-
-    if not prompt.params:
-        # Override the params() method and return None
-        # if there are no params. This improves type
-        # hinting when attempting to access params
-        # that don't exist on the execution context.
-        auto += "\n"
-        auto += f"{indent()}@property\n"
-        auto += f"{indent()}def params(self) -> None:\n"
-        auto += f"{indent(2)}return None\n"
 
     return auto
 
@@ -267,7 +260,7 @@ def generate_code_for_prompt(prompt: Prompt) -> str:
         [
             x
             for x in [
-                generate_params_class_code(prompt) if prompt.params else None,
+                generate_params_class_code(prompt),
                 generate_template_renderer_class_code(prompt),
                 generate_execution_context_class_code(prompt),
                 generate_minor_versions_enum_code(prompt),

--- a/autoblocks/_impl/testing/util.py
+++ b/autoblocks/_impl/testing/util.py
@@ -3,12 +3,14 @@ import hashlib
 from typing import Any
 from typing import Generator
 from typing import Optional
+from typing import Sequence
 
 import orjson
 
 from autoblocks._impl.testing.models import BaseTestCase
 from autoblocks._impl.testing.models import TestCaseConfig
 from autoblocks._impl.testing.models import TestCaseContext
+from autoblocks._impl.testing.models import TestCaseType
 
 # This attribute name might sound redundant but it is named this
 # way (as opposed to just `config`) to decrease the likelihood
@@ -54,7 +56,7 @@ def serialize_test_case(test_case: BaseTestCase) -> Any:
     return serialize(test_case)
 
 
-def config_from_test_case(test_case: BaseTestCase) -> Optional[TestCaseConfig]:
+def config_from_test_case(test_case: TestCaseType) -> Optional[TestCaseConfig]:
     config = getattr(test_case, TEST_CASE_CONFIG_ATTR, None)
     if isinstance(config, TestCaseConfig):
         return config
@@ -62,8 +64,8 @@ def config_from_test_case(test_case: BaseTestCase) -> Optional[TestCaseConfig]:
 
 
 def yield_test_case_contexts_from_test_cases(
-    test_cases: list[BaseTestCase],
-) -> Generator[TestCaseContext, None, None]:
+    test_cases: Sequence[TestCaseType],
+) -> Generator[TestCaseContext[TestCaseType], None, None]:
     for test_case in test_cases:
         config = config_from_test_case(test_case)
         if not config or config.repeat_num_times is None:

--- a/autoblocks/_impl/tracer.py
+++ b/autoblocks/_impl/tracer.py
@@ -11,6 +11,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Sequence
 from typing import Tuple
 from typing import Union
 
@@ -139,7 +140,7 @@ class AutoblocksTracer:
                 ctx = contextvars.copy_context()
                 return await global_state.event_loop().run_in_executor(
                     None,
-                    ctx.run,
+                    ctx.run,  # type: ignore
                     evaluator.evaluate_event,
                     event,
                 )
@@ -160,7 +161,7 @@ class AutoblocksTracer:
     async def _run_evaluators_unsafe(
         self,
         event: TracerEvent,
-        evaluators: List[BaseEventEvaluator],
+        evaluators: Sequence[BaseEventEvaluator],
     ) -> List[Dict[str, Any]]:
         """
         Run a list of evaluators on an event and return the evaluations as a list of dictionaries.
@@ -188,7 +189,7 @@ class AutoblocksTracer:
     async def _async_send_event(
         self,
         payload: Payload,
-        evaluators: Optional[List[BaseEventEvaluator]],
+        evaluators: Optional[Sequence[BaseEventEvaluator]],
     ) -> None:
         # If there are evaluators, run them and compute the evaluations property
         if evaluators:
@@ -302,7 +303,7 @@ class AutoblocksTracer:
     def _dispatch_event_unsafe(
         self,
         payload: Payload,
-        evaluators: Optional[List[BaseEventEvaluator]],
+        evaluators: Optional[Sequence[BaseEventEvaluator]],
     ) -> None:
         task: AnyTask
 
@@ -346,7 +347,7 @@ class AutoblocksTracer:
         parent_span_id: Optional[str] = None,
         timestamp: Optional[str] = None,
         properties: Optional[Dict[str, Any]] = None,
-        evaluators: Optional[List[BaseEventEvaluator]] = None,
+        evaluators: Optional[Sequence[BaseEventEvaluator]] = None,
         prompt_tracking: Optional[Dict[str, Any]] = None,
     ) -> None:
         """

--- a/autoblocks/api/client.py
+++ b/autoblocks/api/client.py
@@ -1,1 +1,5 @@
-from autoblocks._impl.api.client import AutoblocksAPIClient  # noqa: F401
+from autoblocks._impl.api.client import AutoblocksAPIClient
+
+__all__ = [
+    "AutoblocksAPIClient",
+]

--- a/autoblocks/api/models.py
+++ b/autoblocks/api/models.py
@@ -1,11 +1,25 @@
-from autoblocks._impl.api.models import AbsoluteTimeFilter  # noqa: F401
-from autoblocks._impl.api.models import Event  # noqa: F401
-from autoblocks._impl.api.models import EventFilter  # noqa: F401
-from autoblocks._impl.api.models import EventFilterOperator  # noqa: F401
-from autoblocks._impl.api.models import RelativeTimeFilter  # noqa: F401
-from autoblocks._impl.api.models import SystemEventFilterKey  # noqa: F401
-from autoblocks._impl.api.models import Trace  # noqa: F401
-from autoblocks._impl.api.models import TraceFilter  # noqa: F401
-from autoblocks._impl.api.models import TraceFilterOperator  # noqa: F401
-from autoblocks._impl.api.models import TracesResponse  # noqa: F401
-from autoblocks._impl.api.models import View  # noqa: F401
+from autoblocks._impl.api.models import AbsoluteTimeFilter
+from autoblocks._impl.api.models import Event
+from autoblocks._impl.api.models import EventFilter
+from autoblocks._impl.api.models import EventFilterOperator
+from autoblocks._impl.api.models import RelativeTimeFilter
+from autoblocks._impl.api.models import SystemEventFilterKey
+from autoblocks._impl.api.models import Trace
+from autoblocks._impl.api.models import TraceFilter
+from autoblocks._impl.api.models import TraceFilterOperator
+from autoblocks._impl.api.models import TracesResponse
+from autoblocks._impl.api.models import View
+
+__all__ = [
+    "AbsoluteTimeFilter",
+    "Event",
+    "EventFilter",
+    "EventFilterOperator",
+    "RelativeTimeFilter",
+    "SystemEventFilterKey",
+    "Trace",
+    "TraceFilter",
+    "TraceFilterOperator",
+    "TracesResponse",
+    "View",
+]

--- a/autoblocks/prompts/context.py
+++ b/autoblocks/prompts/context.py
@@ -1,1 +1,5 @@
-from autoblocks._impl.prompts.context import PromptExecutionContext  # noqa: F401
+from autoblocks._impl.prompts.context import PromptExecutionContext
+
+__all__ = [
+    "PromptExecutionContext",
+]

--- a/autoblocks/prompts/manager.py
+++ b/autoblocks/prompts/manager.py
@@ -1,1 +1,5 @@
-from autoblocks._impl.prompts.manager import AutoblocksPromptManager  # noqa: F401
+from autoblocks._impl.prompts.manager import AutoblocksPromptManager
+
+__all__ = [
+    "AutoblocksPromptManager",
+]

--- a/autoblocks/prompts/models.py
+++ b/autoblocks/prompts/models.py
@@ -1,2 +1,7 @@
-from autoblocks._impl.prompts.models import FrozenModel  # noqa: F401
-from autoblocks._impl.prompts.models import WeightedMinorVersion  # noqa: F401
+from autoblocks._impl.prompts.models import FrozenModel
+from autoblocks._impl.prompts.models import WeightedMinorVersion
+
+__all__ = [
+    "FrozenModel",
+    "WeightedMinorVersion",
+]

--- a/autoblocks/prompts/renderer.py
+++ b/autoblocks/prompts/renderer.py
@@ -1,1 +1,5 @@
-from autoblocks._impl.prompts.renderer import TemplateRenderer  # noqa: F401
+from autoblocks._impl.prompts.renderer import TemplateRenderer
+
+__all__ = [
+    "TemplateRenderer",
+]

--- a/autoblocks/testing/models.py
+++ b/autoblocks/testing/models.py
@@ -1,8 +1,19 @@
-from autoblocks._impl.testing.models import BaseEvaluator  # noqa: F401
-from autoblocks._impl.testing.models import BaseEventEvaluator  # noqa: F401
-from autoblocks._impl.testing.models import BaseTestCase  # noqa: F401
-from autoblocks._impl.testing.models import BaseTestEvaluator  # noqa: F401
-from autoblocks._impl.testing.models import Evaluation  # noqa: F401
-from autoblocks._impl.testing.models import TestCaseConfig  # noqa: F401
-from autoblocks._impl.testing.models import Threshold  # noqa: F401
-from autoblocks._impl.testing.models import TracerEvent  # noqa: F401
+from autoblocks._impl.testing.models import BaseEvaluator
+from autoblocks._impl.testing.models import BaseEventEvaluator
+from autoblocks._impl.testing.models import BaseTestCase
+from autoblocks._impl.testing.models import BaseTestEvaluator
+from autoblocks._impl.testing.models import Evaluation
+from autoblocks._impl.testing.models import TestCaseConfig
+from autoblocks._impl.testing.models import Threshold
+from autoblocks._impl.testing.models import TracerEvent
+
+__all__ = [
+    "BaseEvaluator",
+    "BaseEventEvaluator",
+    "BaseTestCase",
+    "BaseTestEvaluator",
+    "Evaluation",
+    "TestCaseConfig",
+    "Threshold",
+    "TracerEvent",
+]

--- a/autoblocks/testing/run.py
+++ b/autoblocks/testing/run.py
@@ -1,1 +1,5 @@
-from autoblocks._impl.testing.run import run_test_suite  # noqa: F401
+from autoblocks._impl.testing.run import run_test_suite
+
+__all__ = [
+    "run_test_suite",
+]

--- a/autoblocks/testing/util.py
+++ b/autoblocks/testing/util.py
@@ -1,1 +1,5 @@
-from autoblocks._impl.testing.util import md5  # noqa: F401
+from autoblocks._impl.testing.util import md5
+
+__all__ = [
+    "md5",
+]

--- a/autoblocks/tracer/__init__.py
+++ b/autoblocks/tracer/__init__.py
@@ -1,2 +1,7 @@
-from autoblocks._impl.global_state import flush  # noqa: F401
-from autoblocks._impl.tracer import AutoblocksTracer  # noqa: F401
+from autoblocks._impl.global_state import flush
+from autoblocks._impl.tracer import AutoblocksTracer
+
+__all__ = [
+    "flush",
+    "AutoblocksTracer",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,12 @@ line-length = 120
 [tool.ruff.lint.isort]
 force-single-line = true
 known-first-party = ["autoblocks"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+explicit_package_bases = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false

--- a/tests/autoblocks/test_prompt_manager.py
+++ b/tests/autoblocks/test_prompt_manager.py
@@ -4,6 +4,7 @@ from enum import Enum
 from http import HTTPStatus
 from unittest import mock
 
+import pydantic
 import pytest
 
 from autoblocks._impl.config.constants import API_ENDPOINT
@@ -13,6 +14,10 @@ from autoblocks.prompts.manager import AutoblocksPromptManager
 from autoblocks.prompts.renderer import TemplateRenderer
 from tests.util import MOCK_CLI_SERVER_ADDRESS
 from tests.util import make_expected_body
+
+
+class MyClassParams(pydantic.BaseModel):
+    pass
 
 
 class MyTemplateRenderer(TemplateRenderer):
@@ -36,11 +41,11 @@ class MyTemplateRenderer(TemplateRenderer):
 
 class MyExecutionContext(
     PromptExecutionContext[
-        None,
+        MyClassParams,
         MyTemplateRenderer,
     ],
 ):
-    __params_class__ = None
+    __params_class__ = MyClassParams
     __template_renderer_class__ = MyTemplateRenderer
 
 

--- a/tests/autoblocks/test_prompts_autogenerate.py
+++ b/tests/autoblocks/test_prompts_autogenerate.py
@@ -212,11 +212,12 @@ def test_write(httpx_mock):
         prompts=[
             AutogeneratePromptConfig(
                 id="prompt-a",
-                major_versions=[1],
+                major_versions=["1"],
             ),
             AutogeneratePromptConfig(
                 id="prompt-b",
-                major_versions=[1, 2],
+                # Test that it works with numbers
+                major_versions=[1, 2],  # type: ignore
             ),
             AutogeneratePromptConfig(
                 id="prompt-c",

--- a/tests/autoblocks/test_prompts_autogenerate.py
+++ b/tests/autoblocks/test_prompts_autogenerate.py
@@ -409,6 +409,10 @@ class PromptB1PromptManager(
     __execution_context_class__ = PromptB1ExecutionContext
 
 
+class PromptB2Params(FrozenModel):
+    pass
+
+
 class PromptB2TemplateRenderer(TemplateRenderer):
     __name_mapper__ = {
         "name": "name",
@@ -451,16 +455,12 @@ class PromptB2TemplateRenderer(TemplateRenderer):
 
 class PromptB2ExecutionContext(
     PromptExecutionContext[
-        None,
+        PromptB2Params,
         PromptB2TemplateRenderer,
     ],
 ):
-    __params_class__ = None
+    __params_class__ = PromptB2Params
     __template_renderer_class__ = PromptB2TemplateRenderer
-
-    @property
-    def params(self) -> None:
-        return None
 
 
 class PromptB2MinorVersion(Enum):

--- a/tests/autoblocks/test_run_test_suite.py
+++ b/tests/autoblocks/test_run_test_suite.py
@@ -317,7 +317,7 @@ def test_error_in_evaluator(httpx_mock):
     def test_fn(test_case: MyTestCase):
         return test_case.input + "!"
 
-    class MySyncEvaluator(BaseTestEvaluator):
+    class MySyncEvaluator(BaseTestEvaluator[MyTestCase, str]):
         id = "my-sync-evaluator"
 
         def evaluate_test_case(self, test_case: MyTestCase, output: str) -> Evaluation:
@@ -328,7 +328,7 @@ def test_error_in_evaluator(httpx_mock):
                 )
             raise ValueError(output)
 
-    class MyAsyncEvaluator(BaseTestEvaluator):
+    class MyAsyncEvaluator(BaseTestEvaluator[MyTestCase, str]):
         id = "my-async-evaluator"
 
         async def evaluate_test_case(self, test_case: MyTestCase, output: str) -> Evaluation:
@@ -510,13 +510,13 @@ def test_with_evaluators(httpx_mock):
     def test_fn(test_case: MyTestCase):
         return test_case.input + "!"
 
-    class EvaluatorA(BaseTestEvaluator):
+    class EvaluatorA(BaseTestEvaluator[MyTestCase, str]):
         id = "evaluator-a"
 
         def evaluate_test_case(self, test_case: MyTestCase, output: str) -> Evaluation:
             return Evaluation(score=0, metadata=dict(reason="because"))
 
-    class EvaluatorB(BaseTestEvaluator):
+    class EvaluatorB(BaseTestEvaluator[MyTestCase, str]):
         id = "evaluator-b"
 
         def evaluate_test_case(self, test_case: MyTestCase, output: str) -> Evaluation:
@@ -543,14 +543,14 @@ def test_concurrency(httpx_mock):
     def test_fn(test_case: MyTestCase):
         return test_case.input + "!"
 
-    class EvaluatorA(BaseTestEvaluator):
+    class EvaluatorA(BaseTestEvaluator[MyTestCase, str]):
         id = "evaluator-a"
         max_concurrency = 1
 
         def evaluate_test_case(self, test_case: MyTestCase, output: str) -> Evaluation:
             return Evaluation(score=0)
 
-    class EvaluatorB(BaseTestEvaluator):
+    class EvaluatorB(BaseTestEvaluator[MyTestCase, str]):
         id = "evaluator-b"
         max_concurrency = 1
 
@@ -784,13 +784,13 @@ def test_async_evaluators(httpx_mock):
     def test_fn(test_case: MyTestCase):
         return test_case.input + "!"
 
-    class EvaluatorA(BaseTestEvaluator):
+    class EvaluatorA(BaseTestEvaluator[MyTestCase, str]):
         id = "evaluator-a"
 
         async def evaluate_test_case(self, test_case: MyTestCase, output: str) -> Evaluation:
             return Evaluation(score=0)
 
-    class EvaluatorB(BaseTestEvaluator):
+    class EvaluatorB(BaseTestEvaluator[MyTestCase, str]):
         id = "evaluator-b"
 
         async def evaluate_test_case(self, test_case: MyTestCase, output: str) -> Evaluation:
@@ -1228,10 +1228,10 @@ def test_repeated_test_cases(httpx_mock):
         def hash(self) -> str:
             return self.input
 
-    class MyEvaluator(BaseTestEvaluator):
+    class MyEvaluator(BaseTestEvaluator[SomeTestCase, str]):
         id = "my-evaluator"
 
-        def evaluate_test_case(self, test_case: MyTestCase, output: str) -> Evaluation:
+        def evaluate_test_case(self, test_case: SomeTestCase, output: str) -> Evaluation:
             return Evaluation(score=ord(test_case.input) / 100)
 
     run_test_suite(
@@ -1312,7 +1312,7 @@ def test_handles_evaluators_implementing_base_evaluator(httpx_mock):
         def hash(self):
             return f"{self.x}"
 
-    class MyCombinedEvaluator(BaseEvaluator):
+    class MyCombinedEvaluator(BaseEvaluator[SomeTestCase, str]):
         id = "my-combined-evaluator"
 
         @staticmethod
@@ -1378,7 +1378,7 @@ def test_evaluators_with_optional_evaluations(httpx_mock):
     class Output:
         actions: list[str]
 
-    class RuleEvaluator(BaseTestEvaluator, abc.ABC):
+    class RuleEvaluator(BaseTestEvaluator[TestCase, Output], abc.ABC):
         @property
         @abc.abstractmethod
         def level(self) -> RuleLevel:

--- a/tests/autoblocks/test_run_test_suite.py
+++ b/tests/autoblocks/test_run_test_suite.py
@@ -75,7 +75,7 @@ def test_invalid_test_cases(httpx_mock):
 
     run_test_suite(
         id="my-test-id",
-        test_cases=[1, 2, 3],
+        test_cases=[1, 2, 3],  # type: ignore
         evaluators=[],
         fn=lambda _: None,
         max_test_case_concurrency=1,
@@ -104,7 +104,7 @@ def test_invalid_evaluators(httpx_mock):
         test_cases=[
             MyTestCase(input="a"),
         ],
-        evaluators=[1, 2, 3],
+        evaluators=[1, 2, 3],  # type: ignore
         fn=lambda _: None,
         max_test_case_concurrency=1,
     )
@@ -158,7 +158,7 @@ def test_error_in_test_fn(httpx_mock):
         ),
     )
 
-    def test_fn(test_case: MyTestCase):
+    def test_fn(test_case: MyTestCase) -> str:
         if test_case.input == "a":
             return test_case.input + "!"
         raise ValueError(test_case.input + "!")
@@ -219,7 +219,7 @@ def test_error_in_async_test_fn(httpx_mock):
         ),
     )
 
-    async def test_fn(test_case: MyTestCase):
+    async def test_fn(test_case: MyTestCase) -> str:
         if test_case.input == "a":
             return test_case.input + "!"
         raise ValueError(test_case.input + "!")
@@ -314,7 +314,7 @@ def test_error_in_evaluator(httpx_mock):
         ),
     )
 
-    def test_fn(test_case: MyTestCase):
+    def test_fn(test_case: MyTestCase) -> str:
         return test_case.input + "!"
 
     class MySyncEvaluator(BaseTestEvaluator[MyTestCase, str]):
@@ -408,7 +408,7 @@ def test_no_evaluators(httpx_mock):
         ),
     )
 
-    def test_fn(test_case: MyTestCase):
+    def test_fn(test_case: MyTestCase) -> str:
         return test_case.input + "!"
 
     run_test_suite(
@@ -507,7 +507,7 @@ def test_with_evaluators(httpx_mock):
         ),
     )
 
-    def test_fn(test_case: MyTestCase):
+    def test_fn(test_case: MyTestCase) -> str:
         return test_case.input + "!"
 
     class EvaluatorA(BaseTestEvaluator[MyTestCase, str]):
@@ -540,7 +540,7 @@ def test_with_evaluators(httpx_mock):
 def test_concurrency(httpx_mock):
     httpx_mock.add_response()
 
-    def test_fn(test_case: MyTestCase):
+    def test_fn(test_case: MyTestCase) -> str:
         return test_case.input + "!"
 
     class EvaluatorA(BaseTestEvaluator[MyTestCase, str]):
@@ -684,7 +684,7 @@ def test_async_test_fn(httpx_mock):
         ),
     )
 
-    async def test_fn(test_case: MyTestCase):
+    async def test_fn(test_case: MyTestCase) -> str:
         return test_case.input + "!"
 
     run_test_suite(
@@ -781,7 +781,7 @@ def test_async_evaluators(httpx_mock):
         body=dict(testExternalId="my-test-id"),
     )
 
-    def test_fn(test_case: MyTestCase):
+    def test_fn(test_case: MyTestCase) -> str:
         return test_case.input + "!"
 
     class EvaluatorA(BaseTestEvaluator[MyTestCase, str]):
@@ -853,7 +853,7 @@ def test_serializes(httpx_mock):
         d: datetime.datetime
         u: uuid.UUID
 
-    def test_fn(test_case: ATestCase):
+    def test_fn(test_case: ATestCase) -> AOutput:
         return AOutput(
             d=test_case.d,
             u=test_case.u,
@@ -1066,7 +1066,7 @@ def test_sends_tracer_events(httpx_mock):
     # this ensures the context variables are being access inside send_event
     tracer = AutoblocksTracer("test")
 
-    async def test_fn(test_case: MyTestCase):
+    async def test_fn(test_case: MyTestCase) -> str:
         if test_case.input == "a":
             # simulate doing more work than b to make sure context manager is working correctly
             await asyncio.sleep(1)

--- a/tests/autoblocks/test_tracer.py
+++ b/tests/autoblocks/test_tracer.py
@@ -378,7 +378,7 @@ def test_tracer_sends_async_evaluations(httpx_mock):
     class MyEvaluator2(BaseEventEvaluator):
         id = "my-evaluator-2"
 
-        async def evaluate_event(self, event: TracerEvent):
+        async def evaluate_event(self, event: TracerEvent) -> Evaluation:
             tracer.send_event(f"i am inside evaluator {self.id} with event {event.message}")
             return Evaluation(
                 score=0.3,
@@ -531,7 +531,7 @@ def test_handles_evaluators_implementing_base_evaluator(httpx_mock):
         def hash(self):
             return f"{self.x}"
 
-    class MyCombinedEvaluator(BaseEvaluator):
+    class MyCombinedEvaluator(BaseEvaluator[SomeTestCase, str]):
         id = "my-combined-evaluator"
 
         @staticmethod

--- a/tests/autoblocks/test_tracer.py
+++ b/tests/autoblocks/test_tracer.py
@@ -32,7 +32,7 @@ def freeze_time():
 
 @pytest.fixture(autouse=True)
 def reset_client():
-    AutoblocksTracer._client = None
+    AutoblocksTracer._client = None  # type: ignore
 
 
 def test_client_headers_init_with_key():
@@ -57,14 +57,14 @@ def test_client_init_headers_with_env_var():
 
 
 def expect_ingestion_post_request(
-    httpx_mock,
+    httpx_mock: Any,
     *,
     message: str,
     trace_id: Optional[str] = None,
     timestamp: Optional[str] = None,
     properties: Optional[dict[str, Any]] = None,
     status_code: int = 200,
-):
+) -> None:
     httpx_mock.add_response(
         url=INGESTION_ENDPOINT,
         method="POST",
@@ -82,9 +82,9 @@ def expect_ingestion_post_request(
 
 
 def expect_cli_post_request(
-    httpx_mock,
+    httpx_mock: Any,
     body: dict[str, Any],
-):
+) -> None:
     httpx_mock.add_response(
         url=INGESTION_ENDPOINT,
         method="POST",
@@ -368,7 +368,7 @@ def test_tracer_sends_async_evaluations(httpx_mock):
     class MyEvaluator1(BaseEventEvaluator):
         id = "my-evaluator-1"
 
-        async def evaluate_event(self, event: TracerEvent):
+        async def evaluate_event(self, event: TracerEvent) -> Evaluation:
             tracer.send_event(f"i am inside evaluator {self.id} with event {event.message}")
             return Evaluation(
                 score=0.9,

--- a/tests/e2e/flask_app.py
+++ b/tests/e2e/flask_app.py
@@ -19,8 +19,8 @@ app = Flask(__name__)
 
 @app.route("/", methods=["POST"])
 def index():
-    trace_id = request.json["trace_id"]
-    sleep_seconds = request.json["sleep_seconds"]
+    trace_id = request.json["trace_id"]  # type: ignore
+    sleep_seconds = request.json["sleep_seconds"]  # type: ignore
     app.logger.info(f"Sending event with trace ID {trace_id}")
     tracer.send_event(
         "e2e-test-event-flask-app",

--- a/tests/e2e/prompts.py
+++ b/tests/e2e/prompts.py
@@ -90,6 +90,10 @@ class UsedByCiDontDeletePromptManager(
     __execution_context_class__ = UsedByCiDontDeleteExecutionContext
 
 
+class UsedByCiDontDeleteNoParamsParams(FrozenModel):
+    pass
+
+
 class UsedByCiDontDeleteNoParamsTemplateRenderer(TemplateRenderer):
     __name_mapper__ = {
         "name": "name",
@@ -108,16 +112,12 @@ class UsedByCiDontDeleteNoParamsTemplateRenderer(TemplateRenderer):
 
 class UsedByCiDontDeleteNoParamsExecutionContext(
     PromptExecutionContext[
-        None,
+        UsedByCiDontDeleteNoParamsParams,
         UsedByCiDontDeleteNoParamsTemplateRenderer,
     ],
 ):
-    __params_class__ = None
+    __params_class__ = UsedByCiDontDeleteNoParamsParams
     __template_renderer_class__ = UsedByCiDontDeleteNoParamsTemplateRenderer
-
-    @property
-    def params(self) -> None:
-        return None
 
 
 class UsedByCiDontDeleteNoParamsMinorVersion(Enum):
@@ -134,6 +134,10 @@ class UsedByCiDontDeleteNoParamsPromptManager(
     __prompt_id__ = "used-by-ci-dont-delete-no-params"
     __prompt_major_version__ = "1"
     __execution_context_class__ = UsedByCiDontDeleteNoParamsExecutionContext
+
+
+class UsedByCiDontDeleteNoParamsUndeployedParams(FrozenModel):
+    pass
 
 
 class UsedByCiDontDeleteNoParamsUndeployedTemplateRenderer(TemplateRenderer):
@@ -157,16 +161,12 @@ class UsedByCiDontDeleteNoParamsUndeployedTemplateRenderer(TemplateRenderer):
 
 class UsedByCiDontDeleteNoParamsUndeployedExecutionContext(
     PromptExecutionContext[
-        None,
+        UsedByCiDontDeleteNoParamsUndeployedParams,
         UsedByCiDontDeleteNoParamsUndeployedTemplateRenderer,
     ],
 ):
-    __params_class__ = None
+    __params_class__ = UsedByCiDontDeleteNoParamsUndeployedParams
     __template_renderer_class__ = UsedByCiDontDeleteNoParamsUndeployedTemplateRenderer
-
-    @property
-    def params(self) -> None:
-        return None
 
 
 class UsedByCiDontDeleteNoParamsUndeployedMinorVersion(Enum):

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -232,7 +232,7 @@ def test_prompt_manager_no_model_params():
     with mgr.exec() as prompt:
         with pytest.raises(AttributeError):
             # This should raise an AttributeError because the prompt has no params
-            prompt.params.model
+            prompt.params.model  # type: ignore
 
         assert prompt.track() == dict(
             id="used-by-ci-dont-delete-no-params",
@@ -252,7 +252,7 @@ def test_prompt_manager_no_model_params_undeployed():
     with mgr.exec() as prompt:
         with pytest.raises(AttributeError):
             # This should raise an AttributeError because the prompt has no params
-            prompt.params.model
+            prompt.params.model  # type: ignore
 
         assert prompt.track()["id"] == "used-by-ci-dont-delete-no-params"
         assert prompt.track()["version"] == "undeployed"

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -230,7 +230,9 @@ def test_prompt_manager_no_model_params():
     )
 
     with mgr.exec() as prompt:
-        assert prompt.params is None
+        with pytest.raises(AttributeError):
+            # This should raise an AttributeError because the prompt has no params
+            prompt.params.model
 
         assert prompt.track() == dict(
             id="used-by-ci-dont-delete-no-params",
@@ -248,7 +250,9 @@ def test_prompt_manager_no_model_params_undeployed():
     )
 
     with mgr.exec() as prompt:
-        assert prompt.params is None
+        with pytest.raises(AttributeError):
+            # This should raise an AttributeError because the prompt has no params
+            prompt.params.model
 
         assert prompt.track()["id"] == "used-by-ci-dont-delete-no-params"
         assert prompt.track()["version"] == "undeployed"

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,10 +1,9 @@
 import json
 from typing import Any
-from typing import Dict
 from typing import Optional
 
 
-def make_expected_body(data: Dict) -> bytes:
+def make_expected_body(data: dict[str, Any]) -> bytes:
     """
     For use in `match_content` in httpx_mock.add_response:
 
@@ -13,7 +12,7 @@ def make_expected_body(data: Dict) -> bytes:
     return json.dumps(data).encode()
 
 
-def decode_request_body(req) -> Dict:
+def decode_request_body(req: Any) -> dict[str, Any]:
     return json.loads(req.content.decode())
 
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -12,7 +12,7 @@ def make_expected_body(data: dict[str, Any]) -> bytes:
     return json.dumps(data).encode()
 
 
-def decode_request_body(req: Any) -> dict[str, Any]:
+def decode_request_body(req: Any) -> Any:
     return json.loads(req.content.decode())
 
 
@@ -20,10 +20,10 @@ MOCK_CLI_SERVER_ADDRESS = "http://localhost:8080"
 
 
 def expect_cli_post_request(
-    httpx_mock,
+    httpx_mock: Any,
     path: str,
     body: Optional[dict[str, Any]],
-):
+) -> None:
     httpx_mock.add_response(
         url=f"{MOCK_CLI_SERVER_ADDRESS}{path}",
         method="POST",


### PR DESCRIPTION
if you run `mypy --strict` on the testing-sdk project in the examples repo you get a ton of errors, this fixes all of them