### PR TITLE
Stop run if /start fails

### DIFF
--- a/tests/autoblocks/test_run_test_suite.py
+++ b/tests/autoblocks/test_run_test_suite.py
@@ -1692,3 +1692,26 @@ def test_alignment_mode_with_test_case_hash(httpx_mock):
     assert requests[0]["body"]["runTestSuiteCalledFromFilepath"].endswith(
         "/python-sdk/tests/autoblocks/test_run_test_suite.py",
     )
+
+
+def test_run_stops_if_start_fails(httpx_mock):
+    expect_cli_post_request(
+        httpx_mock,
+        path="/start",
+        body=dict(testExternalId="my-test-id"),
+        status_code=403,
+    )
+
+    run_test_suite(
+        id="my-test-id",
+        test_cases=[
+            MyTestCase(
+                input="a",
+            ),
+        ],
+        evaluators=[],
+        fn=lambda test_case: test_case.input + "!",
+        max_test_case_concurrency=1,
+    )
+
+    assert len(httpx_mock.get_requests()) == 1

--- a/tests/util.py
+++ b/tests/util.py
@@ -23,10 +23,11 @@ def expect_cli_post_request(
     httpx_mock: Any,
     path: str,
     body: Optional[dict[str, Any]],
+    status_code: int = 200,
 ) -> None:
     httpx_mock.add_response(
         url=f"{MOCK_CLI_SERVER_ADDRESS}{path}",
         method="POST",
-        status_code=200,
+        status_code=status_code,
         match_content=make_expected_body(body) if body is not None else None,
     )


### PR DESCRIPTION
If /start fails all subsequent requests will fail, but the error message that is actually useful will be at the very top of the logs and you'd need to scroll up to see it:

<img width="921" alt="Screenshot 2024-04-17 at 11 33 16 AM" src="https://github.com/autoblocksai/python-sdk/assets/7498009/21bdb3b4-1371-442f-bc79-9fdea9095409">
