### PR TITLE
Explicitly cancel tasks

### DIFF
--- a/autoblocks/_impl/global_state.py
+++ b/autoblocks/_impl/global_state.py
@@ -67,6 +67,8 @@ def _flush_and_shut_down_event_loop() -> None:
         _background_thread.join()
         # Cancel all remaining tasks
         log.debug("Cancelling all remaining tasks")
+        for task in asyncio.all_tasks(_background_event_loop):
+            task.cancel()
         _background_event_loop.run_until_complete(_background_event_loop.shutdown_asyncgens())
         # Close the loop
         log.debug("Closing event loop")


### PR DESCRIPTION
This fixes

```
task: <Task cancelling name='Task-5' coro=<AutoblocksPromptManager._refresh_loop() running at /home/runner/.cache/pypoetry/virtualenvs/user-feedback-clustering-XWtDvoSt-py3.11/lib/python3.11/site-packages/autoblocks/_impl/prompts/manager.py:268> wait_for=<Future pending cb=[Task.task_wakeup()]> cb=[_chain_future.<locals>._call_set_state() at /opt/hostedtoolcache/Python/3.11.8/x64/lib/python3.11/asyncio/futures.py:394]>
```

e2e test logs before:

<img width="1323" alt="Screenshot 2024-04-29 at 9 47 18 AM" src="https://github.com/autoblocksai/python-sdk/assets/7498009/bf718402-f802-4c36-bdab-912ca47e8646">

e2e test logs after:

<img width="1326" alt="Screenshot 2024-04-29 at 9 47 47 AM" src="https://github.com/autoblocksai/python-sdk/assets/7498009/163937da-d10a-461b-9546-807633641c7f">
