### PR TITLE
Update prompts generate CLI to handle revisions

### DIFF
--- a/.autoblocks.yml
+++ b/.autoblocks.yml
@@ -4,9 +4,13 @@ autogenerate:
 
     prompts:
       - id: used-by-ci-dont-delete
-        major_versions:
-          - 2
+        major_version: 2
 
       - id: used-by-ci-dont-delete-no-params
-        major_versions:
-          - 1
+        major_version: 1
+
+      - id: text-summarization
+        dangerously_use_undeployed_revision: latest
+
+      - id: question-answerer
+        dangerously_use_undeployed_revision: clvodtv700003a2z02fumceby

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+exclude: '__snapshots__'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/autoblocks/_impl/config/constants.py
+++ b/autoblocks/_impl/config/constants.py
@@ -1,3 +1,4 @@
 API_ENDPOINT = "https://api.autoblocks.ai"
 INGESTION_ENDPOINT = "https://ingest-event.autoblocks.ai"
 REVISION_LATEST = "latest"
+REVISION_UNDEPLOYED = "undeployed"

--- a/autoblocks/_impl/prompts/autogenerate.py
+++ b/autoblocks/_impl/prompts/autogenerate.py
@@ -1,4 +1,3 @@
-import logging
 import re
 from typing import Any
 from typing import Dict
@@ -13,8 +12,6 @@ from autoblocks._impl.config.constants import REVISION_UNDEPLOYED
 from autoblocks._impl.prompts.models import AutogeneratePromptsConfig
 from autoblocks._impl.prompts.models import FrozenModel
 from autoblocks._impl.util import AutoblocksEnvVar
-
-log = logging.getLogger(__name__)
 
 
 class TemplateParam(FrozenModel):
@@ -253,12 +250,10 @@ def make_prompts_from_config(
             major = REVISION_UNDEPLOYED
             minor = prompt.dangerously_use_undeployed_revision
         else:
-            log.error(
+            raise ValueError(
                 f"Error in {prompt.id} config: "
-                f"Either `major_version` or `dangerously_use_undeployed_revision` must be specified."
-                f"Skipping prompt."
+                f"Either `major_version` or `dangerously_use_undeployed_revision` must be specified"
             )
-            continue
 
         resp = httpx.get(
             url=f"{API_ENDPOINT}/prompts/{prompt.id}/major/{major}/minor/{minor}",

--- a/autoblocks/_impl/prompts/autogenerate.py
+++ b/autoblocks/_impl/prompts/autogenerate.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from typing import Any
 from typing import Dict
@@ -12,6 +13,8 @@ from autoblocks._impl.config.constants import REVISION_UNDEPLOYED
 from autoblocks._impl.prompts.models import AutogeneratePromptsConfig
 from autoblocks._impl.prompts.models import FrozenModel
 from autoblocks._impl.util import AutoblocksEnvVar
+
+log = logging.getLogger(__name__)
 
 
 class TemplateParam(FrozenModel):
@@ -250,10 +253,12 @@ def make_prompts_from_config(
             major = REVISION_UNDEPLOYED
             minor = prompt.dangerously_use_undeployed_revision
         else:
-            raise ValueError(
+            log.error(
                 f"Error in {prompt.id} config: "
-                f"Either `major_version` or `dangerously_use_undeployed_revision` must be specified"
+                f"Either `major_version` or `dangerously_use_undeployed_revision` must be specified."
+                f"Skipping prompt."
             )
+            continue
 
         resp = httpx.get(
             url=f"{API_ENDPOINT}/prompts/{prompt.id}/major/{major}/minor/{minor}",

--- a/autoblocks/_impl/prompts/autogenerate.py
+++ b/autoblocks/_impl/prompts/autogenerate.py
@@ -250,7 +250,10 @@ def make_prompts_from_config(
             major = REVISION_UNDEPLOYED
             minor = prompt.dangerously_use_undeployed_revision
         else:
-            raise ValueError("Either major_version or dangerously_use_undeployed_revision must be specified")
+            raise ValueError(
+                f"Error in {prompt.id} config: "
+                f"Either `major_version` or `dangerously_use_undeployed_revision` must be specified"
+            )
 
         resp = httpx.get(
             url=f"{API_ENDPOINT}/prompts/{prompt.id}/major/{major}/minor/{minor}",

--- a/autoblocks/_impl/prompts/cli/models.py
+++ b/autoblocks/_impl/prompts/cli/models.py
@@ -1,10 +1,5 @@
-import pydantic
-
 from autoblocks._impl.prompts.models import AutogeneratePromptsConfig
-
-
-class FrozenModel(pydantic.BaseModel):
-    model_config = pydantic.ConfigDict(frozen=True)
+from autoblocks._impl.prompts.models import FrozenModel
 
 
 class AutogenerateConfig(FrozenModel):

--- a/autoblocks/_impl/prompts/manager.py
+++ b/autoblocks/_impl/prompts/manager.py
@@ -4,7 +4,6 @@ import contextlib
 import json
 import logging
 from datetime import timedelta
-from enum import Enum
 from http import HTTPStatus
 from typing import Any
 from typing import ContextManager
@@ -34,7 +33,6 @@ from autoblocks._impl.util import get_running_loop
 log = logging.getLogger(__name__)
 
 ExecutionContextType = TypeVar("ExecutionContextType", bound=PromptExecutionContext[Any, Any])
-MinorVersionEnumType = TypeVar("MinorVersionEnumType", bound=Enum)
 
 
 def is_testing_context() -> bool:
@@ -65,10 +63,7 @@ def prompt_revisions_map() -> dict[str, str]:
 
 class AutoblocksPromptManager(
     abc.ABC,
-    Generic[
-        ExecutionContextType,
-        MinorVersionEnumType,
-    ],
+    Generic[ExecutionContextType],
 ):
     __prompt_id__: str
     __prompt_major_version__: str
@@ -88,8 +83,7 @@ class AutoblocksPromptManager(
         self,
         minor_version: Union[
             str,
-            MinorVersionEnumType,
-            List[WeightedMinorVersion[MinorVersionEnumType]],
+            List[WeightedMinorVersion],
         ],
         api_key: Optional[str] = None,
         init_timeout: timedelta = timedelta(seconds=30),

--- a/poetry.lock
+++ b/poetry.lock
@@ -839,6 +839,20 @@ files = [
 ]
 
 [[package]]
+name = "syrupy"
+version = "4.6.1"
+description = "Pytest Snapshot Test Utility"
+optional = false
+python-versions = ">=3.8.1,<4"
+files = [
+    {file = "syrupy-4.6.1-py3-none-any.whl", hash = "sha256:203e52f9cb9fa749cf683f29bd68f02c16c3bc7e7e5fe8f2fc59bdfe488ce133"},
+    {file = "syrupy-4.6.1.tar.gz", hash = "sha256:37a835c9ce7857eeef86d62145885e10b3cb9615bc6abeb4ce404b3f18e1bb36"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0,<9.0.0"
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -948,4 +962,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9.0"
-content-hash = "bc0b81615aac810fbea57defc2a7fe00b8059d1825bdbabf541cbf75c1ac66ba"
+content-hash = "76f20b1f5e2ccdc4526b3ba3166e16852fbce028310b405a0c60673b1f94bc19"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ types-orjson = "^3.6.2"
 types-click = "^7.1.8"
 flask = "^3.0.2"
 gunicorn = ">=21.2,<23.0"
+syrupy = "^4.6.1"
 
 [tool.poetry.scripts]
 prompts = "autoblocks._impl.prompts.cli.main:main"

--- a/tests/autoblocks/__snapshots__/test_prompts_autogenerate.ambr
+++ b/tests/autoblocks/__snapshots__/test_prompts_autogenerate.ambr
@@ -1,0 +1,206 @@
+# serializer version: 1
+# name: test_write
+  '''
+  ############################################################################
+  # This file was generated automatically by Autoblocks. Do not edit directly.
+  ############################################################################
+  
+  from typing import Union  # noqa: F401
+  
+  import pydantic  # noqa: F401
+  
+  from autoblocks.prompts.context import PromptExecutionContext
+  from autoblocks.prompts.manager import AutoblocksPromptManager
+  from autoblocks.prompts.models import FrozenModel
+  from autoblocks.prompts.renderer import TemplateRenderer
+  
+  
+  class PromptAParams(FrozenModel):
+      frequency_penalty: Union[float, int] = pydantic.Field(..., alias="frequencyPenalty")
+      max_tokens: Union[float, int] = pydantic.Field(..., alias="maxTokens")
+      model: str = pydantic.Field(..., alias="model")
+      presence_penalty: Union[float, int] = pydantic.Field(..., alias="presencePenalty")
+      temperature: Union[float, int] = pydantic.Field(..., alias="temperature")
+      top_p: Union[float, int] = pydantic.Field(..., alias="topP")
+  
+  
+  class PromptATemplateRenderer(TemplateRenderer):
+      __name_mapper__ = {
+          "name": "name",
+          "name-1": "name_1",
+          "name-2": "name_2",
+          "weather": "weather",
+      }
+  
+      def template_a(
+          self,
+          *,
+          name: str,
+          weather: str,
+      ) -> str:
+          return self._render(
+              "template-a",
+              name=name,
+              weather=weather,
+          )
+  
+      def template_b(
+          self,
+          *,
+          name_1: str,
+          name_2: str,
+      ) -> str:
+          return self._render(
+              "template-b",
+              name_1=name_1,
+              name_2=name_2,
+          )
+  
+  
+  class PromptAExecutionContext(
+      PromptExecutionContext[
+          PromptAParams,
+          PromptATemplateRenderer,
+      ],
+  ):
+      __params_class__ = PromptAParams
+      __template_renderer_class__ = PromptATemplateRenderer
+  
+  
+  class PromptAPromptManager(
+      AutoblocksPromptManager[PromptAExecutionContext],
+  ):
+      __prompt_id__ = "prompt-a"
+      __prompt_major_version__ = "1"
+      __execution_context_class__ = PromptAExecutionContext
+  
+  
+  class PromptBParams(FrozenModel):
+      frequency_penalty: Union[float, int] = pydantic.Field(..., alias="frequencyPenalty")
+      max_tokens: Union[float, int] = pydantic.Field(..., alias="maxTokens")
+      model: str = pydantic.Field(..., alias="model")
+      presence_penalty: Union[float, int] = pydantic.Field(..., alias="presencePenalty")
+      temperature: Union[float, int] = pydantic.Field(..., alias="temperature")
+      top_p: Union[float, int] = pydantic.Field(..., alias="topP")
+  
+  
+  class PromptBTemplateRenderer(TemplateRenderer):
+      __name_mapper__ = {
+          "name": "name",
+          "weather": "weather",
+      }
+  
+      def template_a(
+          self,
+          *,
+          name: str,
+          weather: str,
+      ) -> str:
+          return self._render(
+              "template-a",
+              name=name,
+              weather=weather,
+          )
+  
+  
+  class PromptBExecutionContext(
+      PromptExecutionContext[
+          PromptBParams,
+          PromptBTemplateRenderer,
+      ],
+  ):
+      __params_class__ = PromptBParams
+      __template_renderer_class__ = PromptBTemplateRenderer
+  
+  
+  class PromptBPromptManager(
+      AutoblocksPromptManager[PromptBExecutionContext],
+  ):
+      __prompt_id__ = "prompt-b"
+      __prompt_major_version__ = "1"
+      __execution_context_class__ = PromptBExecutionContext
+  
+  
+  class PromptCParams(FrozenModel):
+      pass
+  
+  
+  class PromptCTemplateRenderer(TemplateRenderer):
+      __name_mapper__ = {
+          "name": "name",
+          "weather": "weather",
+      }
+  
+      def template_a(
+          self,
+          *,
+          name: str,
+          weather: str,
+      ) -> str:
+          return self._render(
+              "template-a",
+              name=name,
+              weather=weather,
+          )
+  
+  
+  class PromptCExecutionContext(
+      PromptExecutionContext[
+          PromptCParams,
+          PromptCTemplateRenderer,
+      ],
+  ):
+      __params_class__ = PromptCParams
+      __template_renderer_class__ = PromptCTemplateRenderer
+  
+  
+  class PromptCPromptManager(
+      AutoblocksPromptManager[PromptCExecutionContext],
+  ):
+      __prompt_id__ = "prompt-c"
+      __prompt_major_version__ = "undeployed"
+      __execution_context_class__ = PromptCExecutionContext
+  
+  
+  class PromptDParams(FrozenModel):
+      pass
+  
+  
+  class PromptDTemplateRenderer(TemplateRenderer):
+      __name_mapper__ = {
+          "name": "name",
+          "weather": "weather",
+      }
+  
+      def template_a(
+          self,
+          *,
+          name: str,
+          weather: str,
+      ) -> str:
+          return self._render(
+              "template-a",
+              name=name,
+              weather=weather,
+          )
+  
+  
+  class PromptDExecutionContext(
+      PromptExecutionContext[
+          PromptDParams,
+          PromptDTemplateRenderer,
+      ],
+  ):
+      __params_class__ = PromptDParams
+      __template_renderer_class__ = PromptDTemplateRenderer
+  
+  
+  class PromptDPromptManager(
+      AutoblocksPromptManager[PromptDExecutionContext],
+  ):
+      __prompt_id__ = "prompt-d"
+      __prompt_major_version__ = "undeployed"
+      __execution_context_class__ = PromptDExecutionContext
+  
+  '''
+# ---

--- a/tests/autoblocks/test_prompt_manager.py
+++ b/tests/autoblocks/test_prompt_manager.py
@@ -49,7 +49,7 @@ class MyExecutionContext(
 
 
 class MyPromptManager(
-    AutoblocksPromptManager[MyExecutionContext,],
+    AutoblocksPromptManager[MyExecutionContext],
 ):
     __prompt_id__ = "my-prompt-id"
     __prompt_major_version__ = "1"

--- a/tests/autoblocks/test_prompt_manager.py
+++ b/tests/autoblocks/test_prompt_manager.py
@@ -1,6 +1,5 @@
 import json
 import os
-from enum import Enum
 from http import HTTPStatus
 from unittest import mock
 
@@ -49,16 +48,8 @@ class MyExecutionContext(
     __template_renderer_class__ = MyTemplateRenderer
 
 
-class MyMinorVersion(Enum):
-    v0 = "0"
-    LATEST = "latest"
-
-
 class MyPromptManager(
-    AutoblocksPromptManager[
-        MyExecutionContext,
-        MyMinorVersion,
-    ],
+    AutoblocksPromptManager[MyExecutionContext,],
 ):
     __prompt_id__ = "my-prompt-id"
     __prompt_major_version__ = "1"
@@ -96,7 +87,7 @@ def test_uses_prompt_revision(httpx_mock):
         ),
     )
 
-    mgr = MyPromptManager(MyMinorVersion.v0)
+    mgr = MyPromptManager(minor_version="0")
     with mgr.exec() as p:
         rendered = p.render.my_template(name="Nicole", weather="sunny")
         assert rendered == "Hello, Nicole! The weather is sunny today!!!"
@@ -135,7 +126,7 @@ def test_uses_prompt_revision_when_version_is_latest(httpx_mock):
         ),
     )
 
-    mgr = MyPromptManager(MyMinorVersion.LATEST)
+    mgr = MyPromptManager(minor_version="latest")
     with mgr.exec() as p:
         rendered = p.render.my_template(name="Nicole", weather="sunny")
         assert rendered == "Hello, Nicole! The weather is sunny today!!!"
@@ -169,7 +160,7 @@ def test_uses_configured_version_if_revision_is_for_different_prompt(httpx_mock)
         ),
     )
 
-    mgr = MyPromptManager(MyMinorVersion.v0)
+    mgr = MyPromptManager(minor_version="0")
     with mgr.exec() as p:
         rendered = p.render.my_template(name="Nicole", weather="sunny")
         assert rendered == "Hello, Nicole! The weather is sunny today."
@@ -201,7 +192,7 @@ def test_raises_if_prompt_is_incompatible(httpx_mock):
     )
 
     with pytest.raises(IncompatiblePromptRevisionError) as exc:
-        MyPromptManager(MyMinorVersion.v0)
+        MyPromptManager(minor_version="0")
 
     assert str(exc.value) == (
         "Can't override prompt 'MyPromptManager' with revision 'mock-revision-id' "
@@ -237,7 +228,7 @@ def test_ignores_revision_id_if_not_in_test_run_context(httpx_mock):
         ),
     )
 
-    mgr = MyPromptManager(MyMinorVersion.v0)
+    mgr = MyPromptManager(minor_version="0")
     with mgr.exec() as p:
         rendered = p.render.my_template(name="Nicole", weather="sunny")
         assert rendered == "Hello, Nicole! The weather is sunny today."

--- a/tests/autoblocks/test_prompts_autogenerate.py
+++ b/tests/autoblocks/test_prompts_autogenerate.py
@@ -67,142 +67,134 @@ def test_infer_type():
     assert infer_type(None) is None
 
 
-MOCK_PROMPTS_API_RESPONSE = [
-    {
-        "id": "prompt-a",
-        "params": {
-            "params": {
-                "frequencyPenalty": 0,
-                "maxTokens": 256,
-                "model": "gpt-4",
-                "presencePenalty": 0.3,
-                "stopSequences": [],
-                "temperature": 0.7,
-                "topP": 1,
-            },
-            "version": "1.0",
-        },
-        "templates": [
-            {
-                "id": "template-a",
-                "template": "Hello, {{ name }}! The weather is {{ weather }} today.",
-                "version": "1.0",
-            },
-            {
-                "id": "template-b",
-                "template": "Hello, {{ name-1 }}! My name is {{ name-2 }}.",
-                "version": "1.0",
-            },
-        ],
-        "version": "1.0",
-    },
-    {
-        "id": "prompt-b",
-        "templates": [
-            {
-                "id": "template-a",
-                "template": "Hello, {{ name }}! The weather is {{ weather }} today.",
-                "version": "1.0",
-            },
-            {
-                "id": "template-b",
-                "template": "Hello, {{ name1 }}! My name is {{ name2 }}.",
-                "version": "1.0",
-            },
-            {
-                "id": "template-c",
-                "template": "I am template c and I have no params",
-                "version": "1.0",
-            },
-        ],
-        "version": "2.0",
-    },
-    {
-        "id": "prompt-b",
-        "params": {
-            "params": {
-                "frequencyPenalty": 0,
-                "maxTokens": 256,
-                "model": "gpt-4",
-                "presencePenalty": -0.3,
-                "stopSequences": [],
-                "temperature": 0.7,
-                "topP": 1,
-            },
-            "version": "1.1",
-        },
-        "templates": [
-            {
-                "id": "template-a",
-                "template": "Hello, {{ name }}! The weather is {{ weather }} today.",
-                "version": "1.0",
-            },
-            {
-                "id": "template-b",
-                "template": "Hello, {{ name1 }}! My name is {{ name2 }}.",
-                "version": "1.0",
-            },
-        ],
-        "version": "1.1",
-    },
-    {
-        "id": "prompt-b",
-        "params": {
-            "params": {
-                "frequencyPenalty": 0,
-                "maxTokens": 256,
-                "model": "gpt-4",
-                "presencePenalty": 0.3,
-                "stopSequences": [],
-                "temperature": 0.7,
-                "topP": 1,
-            },
-            "version": "1.0",
-        },
-        "templates": [
-            {
-                "id": "template-a",
-                "template": "Hello, {{ name }}! The weather is {{ weather }} today.",
-                "version": "1.0",
-            },
-            {
-                "id": "template-b",
-                "template": "Hello, {{ name1 }}! My name is {{ name2 }}.",
-                "version": "1.0",
-            },
-        ],
-        "version": "1.0",
-    },
-]
-
-
 @mock.patch.dict(
     os.environ,
     {
         "AUTOBLOCKS_API_KEY": "mock-api-key",
     },
 )
-def test_write(httpx_mock):
+def test_write(httpx_mock, snapshot):
     config = AutogeneratePromptsConfig(
         outfile="test.py",
         prompts=[
             AutogeneratePromptConfig(
                 id="prompt-a",
-                major_versions=["1"],
+                major_version="1",
             ),
             AutogeneratePromptConfig(
                 id="prompt-b",
                 # Test that it works with numbers
-                major_versions=[1, 2],  # type: ignore
+                major_version=1,  # type: ignore
+            ),
+            AutogeneratePromptConfig(
+                id="prompt-c",
+                dangerously_use_undeployed_revision="latest",
+            ),
+            AutogeneratePromptConfig(
+                id="prompt-d",
+                dangerously_use_undeployed_revision="mock-specific-revision-id",
             ),
         ],
     )
 
     httpx_mock.add_response(
-        url=f"{API_ENDPOINT}/prompts",
+        url=f"{API_ENDPOINT}/prompts/prompt-a/major/1/minor/latest",
         method="GET",
         status_code=200,
-        json=MOCK_PROMPTS_API_RESPONSE,
+        json={
+            "id": "prompt-a",
+            "params": {
+                "params": {
+                    "frequencyPenalty": 0,
+                    "maxTokens": 256,
+                    "model": "gpt-4",
+                    "presencePenalty": 0.3,
+                    "stopSequences": [],
+                    "temperature": 0.7,
+                    "topP": 1,
+                },
+                "version": "1.0",
+            },
+            "templates": [
+                {
+                    "id": "template-a",
+                    "template": "Hello, {{ name }}! The weather is {{ weather }} today.",
+                },
+                {
+                    "id": "template-b",
+                    "template": "Hello, {{ name-1 }}! My name is {{ name-2 }}.",
+                },
+            ],
+            "version": "1.0",
+            "revisionId": "mock-revision-id",
+        },
+        match_headers={"Authorization": "Bearer mock-api-key"},
+    )
+
+    httpx_mock.add_response(
+        url=f"{API_ENDPOINT}/prompts/prompt-b/major/1/minor/latest",
+        method="GET",
+        status_code=200,
+        json={
+            "id": "prompt-b",
+            "params": {
+                "params": {
+                    "frequencyPenalty": 0,
+                    "maxTokens": 256,
+                    "model": "gpt-4",
+                    "presencePenalty": -0.3,
+                    "stopSequences": [],
+                    "temperature": 0.7,
+                    "topP": 1,
+                },
+            },
+            "templates": [
+                {
+                    "id": "template-a",
+                    "template": "Hello, {{ name }}! The weather is {{ weather }} today.",
+                },
+            ],
+            "version": "3.1",
+            "revisionId": "mock-revision-id",
+        },
+        match_headers={"Authorization": "Bearer mock-api-key"},
+    )
+
+    httpx_mock.add_response(
+        url=f"{API_ENDPOINT}/prompts/prompt-c/major/undeployed/minor/latest",
+        method="GET",
+        status_code=200,
+        json={
+            "id": "prompt-c",
+            "params": None,
+            "templates": [
+                {
+                    "id": "template-a",
+                    "template": "Hello, {{ name }}! The weather is {{ weather }} today.",
+                },
+            ],
+            "version": "revision:mock-revision-id",
+            "revisionId": "mock-revision-id",
+        },
+        match_headers={"Authorization": "Bearer mock-api-key"},
+    )
+
+    httpx_mock.add_response(
+        url=f"{API_ENDPOINT}/prompts/prompt-d/major/undeployed/minor/mock-specific-revision-id",
+        method="GET",
+        status_code=200,
+        json={
+            "id": "prompt-c",
+            "params": None,
+            "templates": [
+                {
+                    "id": "template-a",
+                    "template": "Hello, {{ name }}! The weather is {{ weather }} today.",
+                },
+            ],
+            "version": "revision:mock-specific-revision-id",
+            "revisionId": "mock-specific-revision-id",
+        },
         match_headers={"Authorization": "Bearer mock-api-key"},
     )
 
@@ -211,229 +203,7 @@ def test_write(httpx_mock):
     with mock.patch("autoblocks._impl.prompts.autogenerate.open", m):
         write_generated_code_for_config(config)
 
-    expected = """############################################################################
-# This file was generated automatically by Autoblocks. Do not edit directly.
-############################################################################
-
-from enum import Enum
-from typing import Union  # noqa: F401
-
-import pydantic
-
-from autoblocks.prompts.context import PromptExecutionContext
-from autoblocks.prompts.manager import AutoblocksPromptManager
-from autoblocks.prompts.models import FrozenModel
-from autoblocks.prompts.renderer import TemplateRenderer
-
-
-class PromptAParams(FrozenModel):
-    frequency_penalty: Union[float, int] = pydantic.Field(..., alias="frequencyPenalty")
-    max_tokens: Union[float, int] = pydantic.Field(..., alias="maxTokens")
-    model: str = pydantic.Field(..., alias="model")
-    presence_penalty: Union[float, int] = pydantic.Field(..., alias="presencePenalty")
-    temperature: Union[float, int] = pydantic.Field(..., alias="temperature")
-    top_p: Union[float, int] = pydantic.Field(..., alias="topP")
-
-
-class PromptATemplateRenderer(TemplateRenderer):
-    __name_mapper__ = {
-        "name": "name",
-        "name-1": "name_1",
-        "name-2": "name_2",
-        "weather": "weather",
-    }
-
-    def template_a(
-        self,
-        *,
-        name: str,
-        weather: str,
-    ) -> str:
-        return self._render(
-            "template-a",
-            name=name,
-            weather=weather,
-        )
-
-    def template_b(
-        self,
-        *,
-        name_1: str,
-        name_2: str,
-    ) -> str:
-        return self._render(
-            "template-b",
-            name_1=name_1,
-            name_2=name_2,
-        )
-
-
-class PromptAExecutionContext(
-    PromptExecutionContext[
-        PromptAParams,
-        PromptATemplateRenderer,
-    ],
-):
-    __params_class__ = PromptAParams
-    __template_renderer_class__ = PromptATemplateRenderer
-
-
-class PromptAMinorVersion(Enum):
-    v0 = "0"
-    LATEST = "latest"
-
-
-class PromptAPromptManager(
-    AutoblocksPromptManager[
-        PromptAExecutionContext,
-        PromptAMinorVersion,
-    ],
-):
-    __prompt_id__ = "prompt-a"
-    __prompt_major_version__ = "1"
-    __execution_context_class__ = PromptAExecutionContext
-
-
-class PromptB1Params(FrozenModel):
-    frequency_penalty: Union[float, int] = pydantic.Field(..., alias="frequencyPenalty")
-    max_tokens: Union[float, int] = pydantic.Field(..., alias="maxTokens")
-    model: str = pydantic.Field(..., alias="model")
-    presence_penalty: Union[float, int] = pydantic.Field(..., alias="presencePenalty")
-    temperature: Union[float, int] = pydantic.Field(..., alias="temperature")
-    top_p: Union[float, int] = pydantic.Field(..., alias="topP")
-
-
-class PromptB1TemplateRenderer(TemplateRenderer):
-    __name_mapper__ = {
-        "name": "name",
-        "name1": "name1",
-        "name2": "name2",
-        "weather": "weather",
-    }
-
-    def template_a(
-        self,
-        *,
-        name: str,
-        weather: str,
-    ) -> str:
-        return self._render(
-            "template-a",
-            name=name,
-            weather=weather,
-        )
-
-    def template_b(
-        self,
-        *,
-        name1: str,
-        name2: str,
-    ) -> str:
-        return self._render(
-            "template-b",
-            name1=name1,
-            name2=name2,
-        )
-
-
-class PromptB1ExecutionContext(
-    PromptExecutionContext[
-        PromptB1Params,
-        PromptB1TemplateRenderer,
-    ],
-):
-    __params_class__ = PromptB1Params
-    __template_renderer_class__ = PromptB1TemplateRenderer
-
-
-class PromptB1MinorVersion(Enum):
-    v0 = "0"
-    v1 = "1"
-    LATEST = "latest"
-
-
-class PromptB1PromptManager(
-    AutoblocksPromptManager[
-        PromptB1ExecutionContext,
-        PromptB1MinorVersion,
-    ],
-):
-    __prompt_id__ = "prompt-b"
-    __prompt_major_version__ = "1"
-    __execution_context_class__ = PromptB1ExecutionContext
-
-
-class PromptB2Params(FrozenModel):
-    pass
-
-
-class PromptB2TemplateRenderer(TemplateRenderer):
-    __name_mapper__ = {
-        "name": "name",
-        "name1": "name1",
-        "name2": "name2",
-        "weather": "weather",
-    }
-
-    def template_a(
-        self,
-        *,
-        name: str,
-        weather: str,
-    ) -> str:
-        return self._render(
-            "template-a",
-            name=name,
-            weather=weather,
-        )
-
-    def template_b(
-        self,
-        *,
-        name1: str,
-        name2: str,
-    ) -> str:
-        return self._render(
-            "template-b",
-            name1=name1,
-            name2=name2,
-        )
-
-    def template_c(
-        self,
-    ) -> str:
-        return self._render(
-            "template-c",
-        )
-
-
-class PromptB2ExecutionContext(
-    PromptExecutionContext[
-        PromptB2Params,
-        PromptB2TemplateRenderer,
-    ],
-):
-    __params_class__ = PromptB2Params
-    __template_renderer_class__ = PromptB2TemplateRenderer
-
-
-class PromptB2MinorVersion(Enum):
-    v0 = "0"
-    LATEST = "latest"
-
-
-class PromptB2PromptManager(
-    AutoblocksPromptManager[
-        PromptB2ExecutionContext,
-        PromptB2MinorVersion,
-    ],
-):
-    __prompt_id__ = "prompt-b"
-    __prompt_major_version__ = "2"
-    __execution_context_class__ = PromptB2ExecutionContext
-"""
-
     m.assert_called_once_with("test.py", "w")
     m().write.assert_called_once()
     write_called_with = m().write.call_args[0][0]
-    assert write_called_with == expected
+    assert write_called_with == snapshot

--- a/tests/autoblocks/test_run_test_suite.py
+++ b/tests/autoblocks/test_run_test_suite.py
@@ -1800,14 +1800,14 @@ def test_prompt_manager_revision_usage(httpx_mock):
         __template_renderer_class__ = MyTemplateRenderer
 
     class PromptManagerA(
-        AutoblocksPromptManager[MyExecutionContext,],
+        AutoblocksPromptManager[MyExecutionContext],
     ):
         __prompt_id__ = "prompt-a"
         __prompt_major_version__ = "1"
         __execution_context_class__ = MyExecutionContext
 
     class PromptManagerB(
-        AutoblocksPromptManager[MyExecutionContext,],
+        AutoblocksPromptManager[MyExecutionContext],
     ):
         __prompt_id__ = "prompt-b"
         __prompt_major_version__ = "undeployed"

--- a/tests/autoblocks/test_run_test_suite.py
+++ b/tests/autoblocks/test_run_test_suite.py
@@ -4,7 +4,6 @@ import dataclasses
 import datetime
 import os
 import uuid
-from enum import Enum
 from typing import Optional
 from unittest import mock
 
@@ -1800,25 +1799,15 @@ def test_prompt_manager_revision_usage(httpx_mock):
         __params_class__ = MyPromptParams
         __template_renderer_class__ = MyTemplateRenderer
 
-    class MyMinorVersion(Enum):
-        v0 = "0"
-        LATEST = "latest"
-
     class PromptManagerA(
-        AutoblocksPromptManager[
-            MyExecutionContext,
-            MyMinorVersion,
-        ],
+        AutoblocksPromptManager[MyExecutionContext,],
     ):
         __prompt_id__ = "prompt-a"
         __prompt_major_version__ = "1"
         __execution_context_class__ = MyExecutionContext
 
     class PromptManagerB(
-        AutoblocksPromptManager[
-            MyExecutionContext,
-            MyMinorVersion,
-        ],
+        AutoblocksPromptManager[MyExecutionContext,],
     ):
         __prompt_id__ = "prompt-b"
         __prompt_major_version__ = "undeployed"
@@ -1848,8 +1837,8 @@ def test_prompt_manager_revision_usage(httpx_mock):
         ),
     )
 
-    mgr_a = PromptManagerA(MyMinorVersion.LATEST)
-    mgr_b = PromptManagerB(MyMinorVersion.v0)
+    mgr_a = PromptManagerA(minor_version="latest")
+    mgr_b = PromptManagerB(minor_version="0")
 
     async def test_fn(test_case: MyTestCase) -> str:
         """

--- a/tests/e2e/prompts.py
+++ b/tests/e2e/prompts.py
@@ -2,15 +2,160 @@
 # This file was generated automatically by Autoblocks. Do not edit directly.
 ############################################################################
 
-from enum import Enum
 from typing import Union  # noqa: F401
 
-import pydantic
+import pydantic  # noqa: F401
 
 from autoblocks.prompts.context import PromptExecutionContext
 from autoblocks.prompts.manager import AutoblocksPromptManager
 from autoblocks.prompts.models import FrozenModel
 from autoblocks.prompts.renderer import TemplateRenderer
+
+
+class QuestionAnswererParams(FrozenModel):
+    top_p: Union[float, int] = pydantic.Field(..., alias="topP")
+    model: str = pydantic.Field(..., alias="model")
+    max_tokens: Union[float, int] = pydantic.Field(..., alias="maxTokens")
+    temperature: Union[float, int] = pydantic.Field(..., alias="temperature")
+    presence_penalty: Union[float, int] = pydantic.Field(..., alias="presencePenalty")
+    frequency_penalty: Union[float, int] = pydantic.Field(..., alias="frequencyPenalty")
+
+
+class QuestionAnswererTemplateRenderer(TemplateRenderer):
+    __name_mapper__ = {
+        "content": "content",
+        "documents": "documents",
+        "idx": "idx",
+        "question": "question",
+    }
+
+    def system(
+        self,
+    ) -> str:
+        return self._render(
+            "system",
+        )
+
+    def user(
+        self,
+        *,
+        documents: str,
+        question: str,
+    ) -> str:
+        return self._render(
+            "user",
+            documents=documents,
+            question=question,
+        )
+
+    def user_doc(
+        self,
+        *,
+        content: str,
+        idx: str,
+    ) -> str:
+        return self._render(
+            "user/doc",
+            content=content,
+            idx=idx,
+        )
+
+
+class QuestionAnswererExecutionContext(
+    PromptExecutionContext[
+        QuestionAnswererParams,
+        QuestionAnswererTemplateRenderer,
+    ],
+):
+    __params_class__ = QuestionAnswererParams
+    __template_renderer_class__ = QuestionAnswererTemplateRenderer
+
+
+class QuestionAnswererPromptManager(
+    AutoblocksPromptManager[QuestionAnswererExecutionContext],
+):
+    __prompt_id__ = "question-answerer"
+    __prompt_major_version__ = "undeployed"
+    __execution_context_class__ = QuestionAnswererExecutionContext
+
+
+class TextSummarizationParams(FrozenModel):
+    top_p: Union[float, int] = pydantic.Field(..., alias="topP")
+    model: str = pydantic.Field(..., alias="model")
+    max_tokens: Union[float, int] = pydantic.Field(..., alias="maxTokens")
+    temperature: Union[float, int] = pydantic.Field(..., alias="temperature")
+    presence_penalty: Union[float, int] = pydantic.Field(..., alias="presencePenalty")
+    frequency_penalty: Union[float, int] = pydantic.Field(..., alias="frequencyPenalty")
+
+
+class TextSummarizationTemplateRenderer(TemplateRenderer):
+    __name_mapper__ = {
+        "document": "document",
+        "lang": "lang",
+        "languageRequirement": "language_requirement",
+        "tone": "tone",
+        "toneRequirement": "tone_requirement",
+    }
+
+    def system(
+        self,
+        *,
+        language_requirement: str,
+        tone_requirement: str,
+    ) -> str:
+        return self._render(
+            "system",
+            language_requirement=language_requirement,
+            tone_requirement=tone_requirement,
+        )
+
+    def user(
+        self,
+        *,
+        document: str,
+    ) -> str:
+        return self._render(
+            "user",
+            document=document,
+        )
+
+    def util_language(
+        self,
+        *,
+        lang: str,
+    ) -> str:
+        return self._render(
+            "util/language",
+            lang=lang,
+        )
+
+    def util_tone(
+        self,
+        *,
+        tone: str,
+    ) -> str:
+        return self._render(
+            "util/tone",
+            tone=tone,
+        )
+
+
+class TextSummarizationExecutionContext(
+    PromptExecutionContext[
+        TextSummarizationParams,
+        TextSummarizationTemplateRenderer,
+    ],
+):
+    __params_class__ = TextSummarizationParams
+    __template_renderer_class__ = TextSummarizationTemplateRenderer
+
+
+class TextSummarizationPromptManager(
+    AutoblocksPromptManager[TextSummarizationExecutionContext],
+):
+    __prompt_id__ = "text-summarization"
+    __prompt_major_version__ = "undeployed"
+    __execution_context_class__ = TextSummarizationExecutionContext
 
 
 class UsedByCiDontDeleteParams(FrozenModel):
@@ -71,19 +216,8 @@ class UsedByCiDontDeleteExecutionContext(
     __template_renderer_class__ = UsedByCiDontDeleteTemplateRenderer
 
 
-class UsedByCiDontDeleteMinorVersion(Enum):
-    v0 = "0"
-    v1 = "1"
-    v2 = "2"
-    v3 = "3"
-    LATEST = "latest"
-
-
 class UsedByCiDontDeletePromptManager(
-    AutoblocksPromptManager[
-        UsedByCiDontDeleteExecutionContext,
-        UsedByCiDontDeleteMinorVersion,
-    ],
+    AutoblocksPromptManager[UsedByCiDontDeleteExecutionContext],
 ):
     __prompt_id__ = "used-by-ci-dont-delete"
     __prompt_major_version__ = "2"
@@ -120,16 +254,8 @@ class UsedByCiDontDeleteNoParamsExecutionContext(
     __template_renderer_class__ = UsedByCiDontDeleteNoParamsTemplateRenderer
 
 
-class UsedByCiDontDeleteNoParamsMinorVersion(Enum):
-    v0 = "0"
-    LATEST = "latest"
-
-
 class UsedByCiDontDeleteNoParamsPromptManager(
-    AutoblocksPromptManager[
-        UsedByCiDontDeleteNoParamsExecutionContext,
-        UsedByCiDontDeleteNoParamsMinorVersion,
-    ],
+    AutoblocksPromptManager[UsedByCiDontDeleteNoParamsExecutionContext],
 ):
     __prompt_id__ = "used-by-ci-dont-delete-no-params"
     __prompt_major_version__ = "1"


### PR DESCRIPTION
* dropped minor version enum (since we're now just requesting the prompts in the yaml config instead of all of them), i think was kind of annoying to import & use anyway b/c you had to run `prompts generate` just to bump the minor version
* updated the schema of the yaml file to match how configs are fetched (you can specify a major version or dangerously_use_undeployed_revision)
* switched to snapshot testing for testing the autogenerated code