### PR TITLE
Add base prefix to base classes

### DIFF
--- a/autoblocks/_impl/testing/evaluators/battle.py
+++ b/autoblocks/_impl/testing/evaluators/battle.py
@@ -94,7 +94,7 @@ async def battle(baseline: str, challenger: str, criteria: str, evaluator_id: st
     )
 
 
-class ManualBattle(BaseTestEvaluator, abc.ABC, Generic[TestCaseType, OutputType]):
+class BaseManualBattle(BaseTestEvaluator, abc.ABC, Generic[TestCaseType, OutputType]):
     """
     The ManualBattle evaluator compares two responses based on a given criteria.
     If you would like to Autoblocks to automatically manage the baseline, use the AutomaticBattle evaluator.
@@ -128,7 +128,7 @@ class ManualBattle(BaseTestEvaluator, abc.ABC, Generic[TestCaseType, OutputType]
         return await battle(baseline=baseline, challenger=mapped_output, criteria=self.criteria, evaluator_id=self.id)
 
 
-class AutomaticBattle(BaseTestEvaluator, abc.ABC, Generic[TestCaseType, OutputType]):
+class BaseAutomaticBattle(BaseTestEvaluator, abc.ABC, Generic[TestCaseType, OutputType]):
     """
     The AutomaticBattle evaluator compares two responses based on a given criteria.
     If the challenger wins, the challenger becomes the new baseline automatically.

--- a/autoblocks/_impl/testing/evaluators/has_all_substrings.py
+++ b/autoblocks/_impl/testing/evaluators/has_all_substrings.py
@@ -9,7 +9,7 @@ from autoblocks._impl.testing.models import TestCaseType
 from autoblocks._impl.testing.models import Threshold
 
 
-class HasAllSubstrings(BaseTestEvaluator, abc.ABC, Generic[TestCaseType, OutputType]):
+class BaseHasAllSubstrings(BaseTestEvaluator, abc.ABC, Generic[TestCaseType, OutputType]):
     """
     The HasAllSubstrings evaluator checks if the output contains all the expected substrings.
     Scores 1 if all substrings are present, 0 otherwise.

--- a/autoblocks/testing/evaluators.py
+++ b/autoblocks/testing/evaluators.py
@@ -1,5 +1,16 @@
-from autoblocks._impl.testing.evaluators.battle import AutomaticBattle
-from autoblocks._impl.testing.evaluators.battle import ManualBattle
-from autoblocks._impl.testing.evaluators.has_all_substrings import HasAllSubstrings
+from autoblocks._impl.testing.evaluators.battle import BaseAutomaticBattle
+from autoblocks._impl.testing.evaluators.battle import BaseAutomaticBattle as AutomaticBattle
+from autoblocks._impl.testing.evaluators.battle import BaseManualBattle
+from autoblocks._impl.testing.evaluators.battle import BaseManualBattle as ManualBattle
+from autoblocks._impl.testing.evaluators.has_all_substrings import BaseHasAllSubstrings
+from autoblocks._impl.testing.evaluators.has_all_substrings import BaseHasAllSubstrings as HasAllSubstrings
 
-__all__ = ["HasAllSubstrings", "AutomaticBattle", "ManualBattle"]
+__all__ = [
+    "BaseHasAllSubstrings",
+    "BaseAutomaticBattle",
+    "BaseManualBattle",
+    # deprecated
+    "HasAllSubstrings",
+    "AutomaticBattle",
+    "ManualBattle",
+]

--- a/tests/autoblocks/test_evaluators.py
+++ b/tests/autoblocks/test_evaluators.py
@@ -7,9 +7,9 @@ import pytest
 from autoblocks._impl.config.constants import API_ENDPOINT
 from autoblocks._impl.util import AutoblocksEnvVar
 from autoblocks._impl.util import ThirdPartyEnvVar
-from autoblocks.testing.evaluators import AutomaticBattle
-from autoblocks.testing.evaluators import HasAllSubstrings
-from autoblocks.testing.evaluators import ManualBattle
+from autoblocks.testing.evaluators import BaseAutomaticBattle
+from autoblocks.testing.evaluators import BaseHasAllSubstrings
+from autoblocks.testing.evaluators import BaseManualBattle
 from autoblocks.testing.models import BaseTestCase
 from autoblocks.testing.run import run_test_suite
 from tests.util import ANY_NUMBER
@@ -112,7 +112,7 @@ def test_has_all_substrings_evaluator(httpx_mock):
     def test_fn(test_case: MyTestCase) -> str:
         return test_case.input
 
-    class MyHasAllSubstrings(HasAllSubstrings[MyTestCase, str]):
+    class HasAllSubstrings(BaseHasAllSubstrings[MyTestCase, str]):
         id = "has-all-substrings"
 
         def test_case_mapper(self, test_case: MyTestCase) -> list[str]:
@@ -128,7 +128,7 @@ def test_has_all_substrings_evaluator(httpx_mock):
             MyTestCase(input="foo", expected_substrings=["bar"]),
         ],
         evaluators=[
-            MyHasAllSubstrings(),
+            HasAllSubstrings(),
         ],
         fn=test_fn,
         max_test_case_concurrency=1,
@@ -197,7 +197,7 @@ def test_manual_battle_evaluator(httpx_mock):
     def test_fn(test_case: MyTestCase) -> str:
         return test_case.input
 
-    class Battle(ManualBattle[MyTestCase, str]):
+    class Battle(BaseManualBattle[MyTestCase, str]):
         id = "battle"
         criteria = "Choose the best greeting."
 
@@ -294,7 +294,7 @@ def test_automatic_battle_evaluator(httpx_mock):
     def test_fn(test_case: MyTestCase) -> str:
         return test_case.input
 
-    class Battle(AutomaticBattle[MyTestCase, str]):
+    class Battle(BaseAutomaticBattle[MyTestCase, str]):
         id = "battle"
         criteria = "Choose the best greeting."
 


### PR DESCRIPTION
we should use `Base*` as a prefix for all our ABCs to be consistent w/ the other classes (`BaseTestEvaluator`, `BaseEventEvaluator`, `BaseTestCase`) and so you don't need to rename the class to e.g. `MyHasAllSubstrings`