### PR TITLE
Always use our background loop when sending events

### DIFF
--- a/autoblocks/_impl/tracer.py
+++ b/autoblocks/_impl/tracer.py
@@ -21,10 +21,8 @@ from autoblocks._impl.testing.models import Evaluation
 from autoblocks._impl.testing.models import HumanReviewField
 from autoblocks._impl.testing.models import TracerEvent
 from autoblocks._impl.testing.util import serialize_human_review_fields
-from autoblocks._impl.util import AnyTask
 from autoblocks._impl.util import AutoblocksEnvVar
 from autoblocks._impl.util import all_settled
-from autoblocks._impl.util import get_running_loop
 from autoblocks._impl.util import now_iso_8601
 
 log = logging.getLogger(__name__)
@@ -315,26 +313,14 @@ class AutoblocksTracer:
         payload: Payload,
         evaluators: Optional[Sequence[BaseEventEvaluator]],
     ) -> None:
-        task: AnyTask
-
-        # Check if we're already in a running event loop
-        if running_loop := get_running_loop():
-            # If we are, execute the task on that loop
-            task = running_loop.create_task(
-                self._async_send_event(
-                    payload=payload,
-                    evaluators=evaluators,
-                ),
-            )
-        else:
-            # Otherwise, send the task to our background loop
-            task = asyncio.run_coroutine_threadsafe(
-                self._async_send_event(
-                    payload=payload,
-                    evaluators=evaluators,
-                ),
-                global_state.event_loop(),
-            )
+        # Send the task to our background loop
+        task = asyncio.run_coroutine_threadsafe(
+            self._async_send_event(
+                payload=payload,
+                evaluators=evaluators,
+            ),
+            global_state.event_loop(),
+        )
 
         # Add the task to the set of tasks the
         # global state will wait to complete

--- a/tests/e2e/async_script.py
+++ b/tests/e2e/async_script.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 tracer = AutoblocksTracer()
 
 
-async def async_fun() -> None:
+async def my_send_event() -> None:
     trace_id = sys.argv[1]
     sleep_seconds = int(sys.argv[2])
     log.info(f"Sending event with trace ID {trace_id}")
@@ -32,4 +32,4 @@ if __name__ == "__main__":
         level=logging.DEBUG,
         format="%(name)s %(asctime)s [%(levelname)s] %(message)s",
     )
-    asyncio.run(async_fun())
+    asyncio.run(my_send_event())

--- a/tests/e2e/async_script.py
+++ b/tests/e2e/async_script.py
@@ -1,0 +1,35 @@
+import asyncio
+import logging
+import sys
+
+from autoblocks.tracer import AutoblocksTracer
+from tests.e2e.slow_evaluators import SlowEvaluator1
+from tests.e2e.slow_evaluators import SlowEvaluator2
+from tests.e2e.test_e2e import E2E_TESTS_EXPECTED_MESSAGE
+
+log = logging.getLogger(__name__)
+
+tracer = AutoblocksTracer()
+
+
+async def async_fun() -> None:
+    trace_id = sys.argv[1]
+    sleep_seconds = int(sys.argv[2])
+    log.info(f"Sending event with trace ID {trace_id}")
+    tracer.send_event(
+        E2E_TESTS_EXPECTED_MESSAGE,
+        trace_id=trace_id,
+        properties=dict(
+            sleep_seconds=sleep_seconds,
+        ),
+        evaluators=[SlowEvaluator1(), SlowEvaluator2()],
+    )
+    log.info("Event fired")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(name)s %(asctime)s [%(levelname)s] %(message)s",
+    )
+    asyncio.run(async_fun())

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -576,3 +576,20 @@ def test_plain_script_flushes_on_exit():
     log.info(f"Process {process.pid} terminated with return code {process.returncode}.")
 
     wait_for_trace_to_exist(test_trace_id)
+
+
+def test_async_script_flushes_on_exit():
+    # Run the script
+    test_trace_id = str(uuid.uuid4())
+    sleep_seconds = 10
+    process = subprocess.Popen(
+        ["python", "async_script.py", test_trace_id, f"{sleep_seconds}"],
+        cwd="tests/e2e",
+        env=dict(os.environ, **{"PYTHONPATH": os.getcwd()}),
+    )
+
+    # Wait for the process to terminate
+    process.wait()
+    log.info(f"Process {process.pid} terminated with return code {process.returncode}.")
+
+    wait_for_trace_to_exist(test_trace_id)


### PR DESCRIPTION
If we use the main loop, the process gets stuck when waiting to flush.