### PR TITLE
Add env variable to disable github comment

### DIFF
--- a/autoblocks/_impl/testing/api.py
+++ b/autoblocks/_impl/testing/api.py
@@ -29,6 +29,7 @@ from autoblocks._impl.util import ThirdPartyEnvVar
 from autoblocks._impl.util import all_settled
 from autoblocks._impl.util import is_ci
 from autoblocks._impl.util import is_cli_running
+from autoblocks._impl.util import is_github_comment_disabled
 
 log = logging.getLogger(__name__)
 
@@ -384,7 +385,7 @@ async def send_slack_notification(
 async def send_github_comment() -> None:
     github_token = ThirdPartyEnvVar.GITHUB_TOKEN.get()
     build_id = AutoblocksEnvVar.CI_TEST_RUN_BUILD_ID.get()
-    if is_cli_running() or not github_token or not build_id or not is_ci():
+    if is_cli_running() or is_github_comment_disabled() or not github_token or not build_id or not is_ci():
         return
 
     log.info(f"Creating GitHub comment for build '{build_id}'.")

--- a/autoblocks/_impl/util.py
+++ b/autoblocks/_impl/util.py
@@ -38,6 +38,7 @@ class AutoblocksEnvVar(StrEnum):
     CI_TEST_RUN_BUILD_ID = "AUTOBLOCKS_CI_TEST_RUN_BUILD_ID"
     SLACK_WEBHOOK_URL = "AUTOBLOCKS_SLACK_WEBHOOK_URL"
     TEST_RUN_MESSAGE = "AUTOBLOCKS_TEST_RUN_MESSAGE"
+    DISABLE_GITHUB_COMMENT = "AUTOBLOCKS_DISABLE_GITHUB_COMMENT"
 
     def get(self) -> Optional[str]:
         return os.environ.get(self.value)
@@ -53,6 +54,10 @@ class ThirdPartyEnvVar(StrEnum):
 
 def is_ci() -> bool:
     return os.environ.get("CI") == "true"
+
+
+def is_github_comment_disabled() -> bool:
+    return AutoblocksEnvVar.DISABLE_GITHUB_COMMENT.get() == "1"
 
 
 def encode_uri_component(s: str) -> str:


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Adds a new environment variable `AUTOBLOCKS_DISABLE_GITHUB_COMMENT` to allow disabling GitHub comment functionality in the Python SDK.

- Added `DISABLE_GITHUB_COMMENT` to `AutoblocksEnvVar` enum in `/autoblocks/_impl/util.py`
- Added `is_github_comment_disabled()` helper function in `/autoblocks/_impl/util.py` to check if comments are disabled
- Modified `send_github_comment()` in `/autoblocks/_impl/testing/api.py` to respect the new environment variable



<!-- /greptile_comment -->