### PR TITLE
Add revision id to data class

### DIFF
--- a/autoblocks/_impl/api/client.py
+++ b/autoblocks/_impl/api/client.py
@@ -236,7 +236,10 @@ class AutoblocksAPIClient:
             name=resp["name"],
             schema_version=f"{resp['schemaVersion']}",
             revision_id=resp["revisionId"],
-            items=[DatasetItem(id=item["id"], splits=item["splits"], data=item["data"]) for item in resp["items"]],
+            items=[
+                DatasetItem(id=item["id"], revision_id=resp["revisionId"], splits=item["splits"], data=item["data"])
+                for item in resp["items"]
+            ],
         )
 
     def get_local_test_runs(self, test_external_id: str) -> List[AutoblocksTestRun]:

--- a/autoblocks/_impl/api/models.py
+++ b/autoblocks/_impl/api/models.py
@@ -191,6 +191,7 @@ class HumanReviewJobTestCaseResult:
 @dataclass
 class DatasetItem:
     id: str
+    revision_id: str
     splits: List[str]
     data: Dict[str, Any]
 


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Added revision tracking functionality to dataset items by introducing a revision_id field to the DatasetItem dataclass and updating the get_dataset method to properly handle revision IDs.

- Added `revision_id: str` field to `DatasetItem` dataclass in `/autoblocks/_impl/api/models.py`
- Updated `get_dataset` method in `/autoblocks/_impl/api/client.py` to pass `revisionId` from API response to `DatasetItem` constructor



<!-- /greptile_comment -->