### PR TITLE
Allow creating a human review job from run_test_suite

### DIFF
--- a/autoblocks/_impl/testing/models.py
+++ b/autoblocks/_impl/testing/models.py
@@ -255,3 +255,13 @@ class EvaluationOverride:
     input_fields: list[EvaluationOverrideField]
     output_fields: list[EvaluationOverrideField]
     comments: list[EvaluationOverrideComment]
+
+
+@dataclasses.dataclass
+class CreateHumanReviewJob:
+    """
+    A request to create a human review job.
+    """
+
+    assignee_email_address: str
+    name: str

--- a/autoblocks/testing/models.py
+++ b/autoblocks/testing/models.py
@@ -3,6 +3,7 @@ from autoblocks._impl.testing.models import BaseEvaluator
 from autoblocks._impl.testing.models import BaseEventEvaluator
 from autoblocks._impl.testing.models import BaseTestCase
 from autoblocks._impl.testing.models import BaseTestEvaluator
+from autoblocks._impl.testing.models import CreateHumanReviewJob
 from autoblocks._impl.testing.models import Evaluation
 from autoblocks._impl.testing.models import EvaluationOverride
 from autoblocks._impl.testing.models import EvaluationOverrideComment
@@ -32,4 +33,5 @@ __all__ = [
     "Threshold",
     "TracerEvent",
     "ScoreChoice",
+    "CreateHumanReviewJob",
 ]

--- a/tests/autoblocks/test_run_test_suite.py
+++ b/tests/autoblocks/test_run_test_suite.py
@@ -22,6 +22,7 @@ from autoblocks._impl.util import StrEnum
 from autoblocks.testing.models import BaseEvaluator
 from autoblocks.testing.models import BaseTestCase
 from autoblocks.testing.models import BaseTestEvaluator
+from autoblocks.testing.models import CreateHumanReviewJob
 from autoblocks.testing.models import Evaluation
 from autoblocks.testing.models import HumanReviewField
 from autoblocks.testing.models import HumanReviewFieldContentType
@@ -1118,6 +1119,76 @@ def test_async_evaluators(httpx_mock):
         ],
         fn=test_fn,
         max_test_case_concurrency=1,
+    )
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "AUTOBLOCKS_API_KEY": "mock-api-key",
+    },
+)
+def test_creates_human_review_job(httpx_mock):
+    mock_run_id = str(uuid.uuid4())
+    expect_cli_post_request(
+        httpx_mock,
+        path="/start",
+        body=dict(
+            testExternalId="my-test-id",
+            gridSearchRunGroupId=None,
+            gridSearchParamsCombo=None,
+        ),
+        json=dict(id=mock_run_id),
+    )
+    expect_cli_post_request(
+        httpx_mock,
+        path="/results",
+        body=dict(
+            testExternalId="my-test-id",
+            runId=mock_run_id,
+            testCaseHash="a",
+            testCaseBody=dict(input="a"),
+            testCaseOutput="a!",
+            testCaseDurationMs=ANY_NUMBER,
+            testCaseRevisionUsage=None,
+            testCaseHumanReviewInputFields=None,
+            testCaseHumanReviewOutputFields=None,
+            datasetItemId=None,
+        ),
+        json=dict(id="mock-result-id-1"),
+    )
+    expect_cli_post_request(
+        httpx_mock,
+        path="/end",
+        body=dict(
+            testExternalId="my-test-id",
+            runId=mock_run_id,
+        ),
+    )
+    expect_api_post_request(
+        httpx_mock,
+        path=f"/testing/local/runs/{mock_run_id}/human-review-job",
+        body=dict(
+            assigneeEmailAddress="test@test.com",
+            name="test",
+        ),
+    )
+
+    async def test_fn(test_case: MyTestCase) -> str:
+        return test_case.input + "!"
+
+    run_test_suite(
+        id="my-test-id",
+        test_cases=[
+            MyTestCase(input="a"),
+        ],
+        evaluators=[],
+        fn=test_fn,
+        max_test_case_concurrency=1,
+        human_review_job=CreateHumanReviewJob(
+            assignee_email_address="test@test.com",
+            name="test",
+        ),
     )
 
 

--- a/tests/autoblocks/test_run_test_suite.py
+++ b/tests/autoblocks/test_run_test_suite.py
@@ -1126,6 +1126,7 @@ def test_async_evaluators(httpx_mock):
     os.environ,
     {
         "AUTOBLOCKS_API_KEY": "mock-api-key",
+        "CI": "false",
     },
 )
 def test_creates_human_review_job(httpx_mock):


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Added functionality to create human review jobs from test suites through the `run_test_suite` function, enabling automated creation of review tasks after test runs complete.

- Added new `CreateHumanReviewJob` dataclass with `assignee_email_address` and `name` fields in `/autoblocks/_impl/testing/models.py`
- Added optional `human_review_job` parameter to `run_test_suite` in `/autoblocks/_impl/testing/run.py` with error handling that logs warnings but doesn't fail test runs
- Added `CreateHumanReviewJob` to public API through `/autoblocks/testing/models.py` exports
- Added test coverage in `/tests/autoblocks/test_run_test_suite.py` verifying human review job creation with correct parameters



<!-- /greptile_comment -->