### PR TITLE
EPD-1873: update Python SDK to use slug

### DIFF
--- a/autoblocks/_impl/prompts/manager.py
+++ b/autoblocks/_impl/prompts/manager.py
@@ -210,6 +210,7 @@ class AutoblocksPromptManager(
         # via gather and zipping together the minor versions to
         # their results.
         minor_versions = sorted(self._minor_version.all_minor_versions)
+
         try:
             prompts = await asyncio.gather(
                 *[self._get_prompt(minor_version, self._init_timeout) for minor_version in minor_versions],

--- a/autoblocks/_impl/prompts/v2/discovery/__init__.py
+++ b/autoblocks/_impl/prompts/v2/discovery/__init__.py
@@ -58,10 +58,13 @@ class PromptModulesGenerator:
             Dictionary mapping app IDs to app data.
         """
         apps_map: Dict[str, AppData] = {}
+
         for prompt in prompts:
             app_id = prompt.app_id
+
             if app_id not in apps_map:
                 apps_map[app_id] = {"app_id": app_id, "app_name": prompt.app_name, "prompts": []}
+
             prompts_list = cast(List[Prompt], apps_map[app_id]["prompts"])
             prompts_list.append(prompt)
         return apps_map

--- a/autoblocks/_impl/prompts/v2/discovery/app_generation.py
+++ b/autoblocks/_impl/prompts/v2/discovery/app_generation.py
@@ -45,7 +45,9 @@ class AppGenerator:
             init_code.extend(
                 [
                     f"def {function_name}(",
-                    "    major_version: Optional[str] = None,",
+                    "    major_version: "
+                    + ('str = "undeployed"' if prompt.is_undeployed else "Optional[str] = None")
+                    + ",",
                     "    minor_version: str = '0',",
                     "    api_key: Optional[str] = None,",
                     "    init_timeout: Optional[float] = None,",

--- a/autoblocks/_impl/prompts/v2/models.py
+++ b/autoblocks/_impl/prompts/v2/models.py
@@ -55,7 +55,7 @@ class Prompt(FrozenModel):
 
     id: str
     app_id: str = pydantic.Field(..., alias="appId")
-    app_name: str = pydantic.Field(..., alias="appName")
+    app_name: str = pydantic.Field(..., alias="slug")
     major_versions: List[MajorVersion] = pydantic.Field(..., alias="majorVersions")
 
     @property

--- a/tests/e2e/autoblocks_prompts/__init__.py
+++ b/tests/e2e/autoblocks_prompts/__init__.py
@@ -6,5 +6,5 @@ from .apps import app_sdk_test
 from .apps import sdk_test_app_v3
 
 # Make apps available at top level
-sdk_test_app_v3 = sdk_test_app_v3
 app_sdk_test = app_sdk_test
+sdk_test_app_v3 = sdk_test_app_v3

--- a/tests/e2e/autoblocks_prompts/apps/app_sdk_test/prompts.py
+++ b/tests/e2e/autoblocks_prompts/apps/app_sdk_test/prompts.py
@@ -13,8 +13,7 @@ from autoblocks.prompts.v2.renderer import ToolRenderer
 
 
 class _PromptBasicV2Params(FrozenModel):
-    top_k: Union[float, int] = pydantic.Field(..., alias="topK")
-    seed: Union[float, int] = pydantic.Field(..., alias="seed")
+    max_tokens: Union[float, int] = pydantic.Field(..., alias="maxTokens")
     model: str = pydantic.Field(..., alias="model")
 
 
@@ -47,19 +46,13 @@ class _PromptBasicV2ExecutionContext(
 
 
 class _PromptBasicV2PromptManager(AutoblocksPromptManager[_PromptBasicV2ExecutionContext]):
-    __app_id__ = "r12a493gwnntlv17i61kryc6"
+    __app_id__ = "uu95770k1muazxpbi4gazisr"
     __prompt_id__ = "prompt-basic"
     __prompt_major_version__ = "2"
     __execution_context_class__ = _PromptBasicV2ExecutionContext
 
 
 class _PromptBasicV1Params(FrozenModel):
-    temperature: Union[float, int] = pydantic.Field(..., alias="temperature")
-    top_p: Union[float, int] = pydantic.Field(..., alias="topP")
-    frequency_penalty: Union[float, int] = pydantic.Field(..., alias="frequencyPenalty")
-    presence_penalty: Union[float, int] = pydantic.Field(..., alias="presencePenalty")
-    max_tokens: Union[float, int] = pydantic.Field(..., alias="maxTokens")
-    stop_sequences: list[str] = pydantic.Field(..., alias="stopSequences")
     model: str = pydantic.Field(..., alias="model")
 
 
@@ -81,16 +74,6 @@ class _PromptBasicV1TemplateRenderer(TemplateRenderer):
             weather=weather,
         )
 
-    def template_b(
-        self,
-        *,
-        name: str,
-    ) -> str:
-        return self._render(
-            "template-b",
-            name=name,
-        )
-
 
 class _PromptBasicV1ToolRenderer(ToolRenderer):
     __name_mapper__ = {}
@@ -105,7 +88,7 @@ class _PromptBasicV1ExecutionContext(
 
 
 class _PromptBasicV1PromptManager(AutoblocksPromptManager[_PromptBasicV1ExecutionContext]):
-    __app_id__ = "r12a493gwnntlv17i61kryc6"
+    __app_id__ = "uu95770k1muazxpbi4gazisr"
     __prompt_id__ = "prompt-basic"
     __prompt_major_version__ = "1"
     __execution_context_class__ = _PromptBasicV1ExecutionContext

--- a/tests/e2e/autoblocks_prompts/apps/sdk_test_app_v3/__init__.py
+++ b/tests/e2e/autoblocks_prompts/apps/sdk_test_app_v3/__init__.py
@@ -1,30 +1,12 @@
-# Auto-generated prompt module for app: SDK Test App V3
+# Auto-generated prompt module for app: sdk-test-app-v3
 from typing import Any
 from typing import Optional
 
 from . import prompts
 
 
-def do_not_deploy_prompt_manager(
-    major_version: str = "undeployed",
-    minor_version: str = "0",
-    api_key: Optional[str] = None,
-    init_timeout: Optional[float] = None,
-    refresh_timeout: Optional[float] = None,
-    refresh_interval: Optional[float] = None,
-) -> Any:
-    return prompts.DoNotDeployFactory.create(
-        major_version=major_version,
-        minor_version=minor_version,
-        api_key=api_key,
-        init_timeout=init_timeout,
-        refresh_timeout=refresh_timeout,
-        refresh_interval=refresh_interval,
-    )
-
-
 def prompt_basic_prompt_manager(
-    major_version: Optional[str] = None,
+    major_version: str = "undeployed",
     minor_version: str = "0",
     api_key: Optional[str] = None,
     init_timeout: Optional[float] = None,

--- a/tests/e2e/autoblocks_prompts/apps/sdk_test_app_v3/prompts.py
+++ b/tests/e2e/autoblocks_prompts/apps/sdk_test_app_v3/prompts.py
@@ -1,6 +1,7 @@
 from typing import Any
 from typing import Dict
 from typing import Optional
+from typing import Union
 
 import pydantic
 
@@ -11,11 +12,12 @@ from autoblocks.prompts.v2.renderer import TemplateRenderer
 from autoblocks.prompts.v2.renderer import ToolRenderer
 
 
-class _DoNotDeployUndeployedParams(FrozenModel):
-    pass
+class _PromptBasicUndeployedParams(FrozenModel):
+    max_tokens: Union[float, int] = pydantic.Field(..., alias="maxTokens")
+    model: str = pydantic.Field(..., alias="model")
 
 
-class _DoNotDeployUndeployedTemplateRenderer(TemplateRenderer):
+class _PromptBasicUndeployedTemplateRenderer(TemplateRenderer):
     __name_mapper__ = {}
 
     def test_do_not_deploy(
@@ -26,28 +28,28 @@ class _DoNotDeployUndeployedTemplateRenderer(TemplateRenderer):
         )
 
 
-class _DoNotDeployUndeployedToolRenderer(ToolRenderer):
+class _PromptBasicUndeployedToolRenderer(ToolRenderer):
     __name_mapper__ = {}
 
 
-class _DoNotDeployUndeployedExecutionContext(
+class _PromptBasicUndeployedExecutionContext(
     PromptExecutionContext[
-        _DoNotDeployUndeployedParams, _DoNotDeployUndeployedTemplateRenderer, _DoNotDeployUndeployedToolRenderer
+        _PromptBasicUndeployedParams, _PromptBasicUndeployedTemplateRenderer, _PromptBasicUndeployedToolRenderer
     ]
 ):
-    __params_class__ = _DoNotDeployUndeployedParams
-    __template_renderer_class__ = _DoNotDeployUndeployedTemplateRenderer
-    __tool_renderer_class__ = _DoNotDeployUndeployedToolRenderer
+    __params_class__ = _PromptBasicUndeployedParams
+    __template_renderer_class__ = _PromptBasicUndeployedTemplateRenderer
+    __tool_renderer_class__ = _PromptBasicUndeployedToolRenderer
 
 
-class _DoNotDeployUndeployedPromptManager(AutoblocksPromptManager[_DoNotDeployUndeployedExecutionContext]):
-    __app_id__ = "h12a6fsmomuar1ww4fuxbjgl"
-    __prompt_id__ = "do-not-deploy"
+class _PromptBasicUndeployedPromptManager(AutoblocksPromptManager[_PromptBasicUndeployedExecutionContext]):
+    __app_id__ = "b108cei22gakuuujcbtnrt2a"
+    __prompt_id__ = "prompt-basic"
     __prompt_major_version__ = "undeployed"
-    __execution_context_class__ = _DoNotDeployUndeployedExecutionContext
+    __execution_context_class__ = _PromptBasicUndeployedExecutionContext
 
 
-class DoNotDeployFactory:
+class PromptBasicFactory:
     @staticmethod
     def create(
         major_version: str = "undeployed",
@@ -56,7 +58,7 @@ class DoNotDeployFactory:
         init_timeout: Optional[float] = None,
         refresh_timeout: Optional[float] = None,
         refresh_interval: Optional[float] = None,
-    ) -> _DoNotDeployUndeployedPromptManager:
+    ) -> _PromptBasicUndeployedPromptManager:
         kwargs: Dict[str, Any] = {}
         if api_key is not None:
             kwargs["api_key"] = api_key
@@ -70,67 +72,4 @@ class DoNotDeployFactory:
         # Prompt has no deployed versions
         if major_version != "undeployed":
             raise ValueError("Unsupported major version. This prompt has no deployed versions.")
-        return _DoNotDeployUndeployedPromptManager(minor_version=minor_version, **kwargs)
-
-
-class _PromptBasicV1Params(FrozenModel):
-    model: str = pydantic.Field(..., alias="model")
-
-
-class _PromptBasicV1TemplateRenderer(TemplateRenderer):
-    __name_mapper__ = {}
-
-    def test(
-        self,
-    ) -> str:
-        return self._render(
-            "test",
-        )
-
-
-class _PromptBasicV1ToolRenderer(ToolRenderer):
-    __name_mapper__ = {}
-
-
-class _PromptBasicV1ExecutionContext(
-    PromptExecutionContext[_PromptBasicV1Params, _PromptBasicV1TemplateRenderer, _PromptBasicV1ToolRenderer]
-):
-    __params_class__ = _PromptBasicV1Params
-    __template_renderer_class__ = _PromptBasicV1TemplateRenderer
-    __tool_renderer_class__ = _PromptBasicV1ToolRenderer
-
-
-class _PromptBasicV1PromptManager(AutoblocksPromptManager[_PromptBasicV1ExecutionContext]):
-    __app_id__ = "h12a6fsmomuar1ww4fuxbjgl"
-    __prompt_id__ = "prompt-basic"
-    __prompt_major_version__ = "1"
-    __execution_context_class__ = _PromptBasicV1ExecutionContext
-
-
-class PromptBasicFactory:
-    @staticmethod
-    def create(
-        major_version: Optional[str] = None,
-        minor_version: str = "0",
-        api_key: Optional[str] = None,
-        init_timeout: Optional[float] = None,
-        refresh_timeout: Optional[float] = None,
-        refresh_interval: Optional[float] = None,
-    ) -> _PromptBasicV1PromptManager:
-        kwargs: Dict[str, Any] = {}
-        if api_key is not None:
-            kwargs["api_key"] = api_key
-        if init_timeout is not None:
-            kwargs["init_timeout"] = init_timeout
-        if refresh_timeout is not None:
-            kwargs["refresh_timeout"] = refresh_timeout
-        if refresh_interval is not None:
-            kwargs["refresh_interval"] = refresh_interval
-
-        if major_version is None:
-            major_version = "1"  # Latest version
-
-        if major_version == "1":
-            return _PromptBasicV1PromptManager(minor_version=minor_version, **kwargs)
-
-        raise ValueError("Unsupported major version. Available versions: 1")
+        return _PromptBasicUndeployedPromptManager(minor_version=minor_version, **kwargs)

--- a/tests/e2e/test_prompts_v2.py
+++ b/tests/e2e/test_prompts_v2.py
@@ -93,7 +93,7 @@ def test_sdk_test_app_v3_prompt_basic():
 
 def test_sdk_test_app_v3_undeployed_prompt():
     """Test an undeployed prompt from sdk_test_app_v3."""
-    mgr = sdk_test_app_v3.do_not_deploy_prompt_manager(
+    mgr = sdk_test_app_v3.prompt_basic_prompt_manager(
         minor_version="latest",
     )
 

--- a/tests/e2e/test_prompts_v2.py
+++ b/tests/e2e/test_prompts_v2.py
@@ -15,36 +15,23 @@ def test_app_sdk_test_prompt_basic_v1():
 
     with mgr.exec() as ctx:
         # Assert parameters
-        assert ctx.params.max_tokens == 256
         assert ctx.params.model == "gpt-4o"
-        assert ctx.params.temperature == 0.7
-        assert ctx.params.top_p == 1
-        assert ctx.params.frequency_penalty == 0
-        assert ctx.params.presence_penalty == 0
-        assert ctx.params.stop_sequences == []
 
         assert (
             ctx.render_template.template_a(
                 name="Alice",
                 weather="sunny",
             )
-            == "Hello,Alice! The weather is sunny today."
-        )
-
-        assert (
-            ctx.render_template.template_b(
-                name="Alice",
-            )
-            == "Hello, {{ optional? }}! My name is Alice."
+            == "Hello, Alice! The weather is sunny today."
         )
 
         track_info = ctx.track()
 
         assert track_info["id"] == "prompt-basic"
         assert track_info["version"].startswith("1.")
-        assert track_info["appId"] == "r12a493gwnntlv17i61kryc6"
+        assert track_info["appId"] == "uu95770k1muazxpbi4gazisr"
         assert "templates" in track_info
-        assert len(track_info["templates"]) == 2
+        assert len(track_info["templates"]) == 1
 
 
 def test_app_sdk_test_prompt_basic_v2():
@@ -57,8 +44,7 @@ def test_app_sdk_test_prompt_basic_v2():
     with mgr.exec() as ctx:
         # Assert parameters
         assert ctx.params.model == "gpt-4o"
-        assert ctx.params.top_k == 0
-        assert ctx.params.seed == 4096
+        assert ctx.params.max_tokens == 256
 
         # Test template rendering
         assert (
@@ -72,23 +58,9 @@ def test_app_sdk_test_prompt_basic_v2():
         track_info = ctx.track()
         assert track_info["id"] == "prompt-basic"
         assert track_info["version"].startswith("2.")
-        assert track_info["appId"] == "r12a493gwnntlv17i61kryc6"
+        assert track_info["appId"] == "uu95770k1muazxpbi4gazisr"
         assert "templates" in track_info
         assert len(track_info["templates"]) == 1
-
-
-def test_sdk_test_app_v3_prompt_basic():
-    """Test the sdk_test_app_v3.prompt_basic."""
-    mgr = sdk_test_app_v3.prompt_basic_prompt_manager(
-        minor_version="0",
-    )
-
-    with mgr.exec() as ctx:
-
-        track_info = ctx.track()
-        assert track_info["id"] == "prompt-basic"
-        assert track_info["version"].startswith("1.")
-        assert track_info["appId"] == "h12a6fsmomuar1ww4fuxbjgl"
 
 
 def test_sdk_test_app_v3_undeployed_prompt():
@@ -98,9 +70,8 @@ def test_sdk_test_app_v3_undeployed_prompt():
     )
 
     with mgr.exec() as ctx:
-
         track_info = ctx.track()
 
-        assert track_info["id"] == "do-not-deploy"
-        assert track_info["version"] == "revision:l9hi024jgqdwakztbvrbr1t2"
-        assert track_info["appId"] == "h12a6fsmomuar1ww4fuxbjgl"
+        assert track_info["id"] == "prompt-basic"
+        assert track_info["version"] == "revision:jf6a0401grzkg2nfn20gx4ox"
+        assert track_info["appId"] == "b108cei22gakuuujcbtnrt2a"


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

The PR updates the Python SDK to adopt a slug-based naming convention, with minor formatting changes and adjusted defaults in prompt manager and app generation functions.

• In autoblocks/_impl/prompts/manager.py, a formatting update adds a blank line without affecting prompt initialization logic.  
• In autoblocks/_impl/prompts/v2/discovery/app_generation.py, the major_version default is set to 'undeployed' for undeployed prompts.  
• In autoblocks/_impl/prompts/v2/models.py, the Prompt model’s app_name alias is changed to slug to align with naming.  
• Test files in tests/e2e (both apps and test_prompts_v2.py) have been updated to reflect these slug changes and revised parameter assertions.



<!-- /greptile_comment -->