### PR TITLE
Add support for multiple assignees

### DIFF
--- a/autoblocks/_impl/testing/models.py
+++ b/autoblocks/_impl/testing/models.py
@@ -263,5 +263,10 @@ class CreateHumanReviewJob:
     A request to create a human review job.
     """
 
-    assignee_email_address: str
+    assignee_email_address: Union[str, list[str]]
     name: str
+
+    def get_assignee_email_addresses(self) -> list[str]:
+        if isinstance(self.assignee_email_address, str):
+            return [self.assignee_email_address]
+        return self.assignee_email_address

--- a/autoblocks/_impl/testing/run.py
+++ b/autoblocks/_impl/testing/run.py
@@ -421,12 +421,16 @@ async def run_test_suite_for_grid_combo(
     if human_review_job is not None:
         try:
             assignee_email_addresses = human_review_job.get_assignee_email_addresses()
-            for assignee_email_address in assignee_email_addresses:
-                await send_create_human_review_job(
-                    run_id=run_id,
-                    assignee_email_address=assignee_email_address,
-                    name=human_review_job.name,
-                )
+            await all_settled(
+                [
+                    send_create_human_review_job(
+                        run_id=run_id,
+                        assignee_email_address=assignee_email_address,
+                        name=human_review_job.name,
+                    )
+                    for assignee_email_address in assignee_email_addresses
+                ]
+            )
         except Exception as err:
             log.warn(f"Failed to create human review job for test run '{run_id}'", exc_info=err)
 

--- a/autoblocks/_impl/testing/run.py
+++ b/autoblocks/_impl/testing/run.py
@@ -420,11 +420,13 @@ async def run_test_suite_for_grid_combo(
 
     if human_review_job is not None:
         try:
-            await send_create_human_review_job(
-                run_id=run_id,
-                assignee_email_address=human_review_job.assignee_email_address,
-                name=human_review_job.name,
-            )
+            assignee_email_addresses = human_review_job.get_assignee_email_addresses()
+            for assignee_email_address in assignee_email_addresses:
+                await send_create_human_review_job(
+                    run_id=run_id,
+                    assignee_email_address=assignee_email_address,
+                    name=human_review_job.name,
+                )
         except Exception as err:
             log.warn(f"Failed to create human review job for test run '{run_id}'", exc_info=err)
 


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR adds multi-assignee support for human review jobs by updating the review job model, review workflow in the test runner, and corresponding tests.  
- Updated full filepath /autoblocks/_impl/testing/models.py to allow assignee_email_address as string or list and added get_assignee_email_addresses.  
- Modified /autoblocks/_impl/testing/run.py to concurrently send review job requests for each assignee using all_settled.  
- Added tests in /tests/autoblocks/test_run_test_suite.py to validate multiple API calls per assignee.



<!-- /greptile_comment -->