### PR TITLE
remove invalid arg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,7 @@ jobs:
         run: npx --package renovate renovate-config-validator --strict
 
   tests:
-    runs-on:
-      - codebuild-autoblocksai-${{ github.run_id }}-${{ github.run_attempt }}
-      - instance-size:small
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,9 @@ jobs:
         run: npx --package renovate renovate-config-validator --strict
 
   tests:
-    runs-on: ubuntu-latest
+    runs-on:
+      - codebuild-autoblocksai-${{ github.run_id }}-${{ github.run_attempt }}
+      - instance-size:small
     timeout-minutes: 5
 
     strategy:

--- a/autoblocks/_impl/datasets/client.py
+++ b/autoblocks/_impl/datasets/client.py
@@ -179,7 +179,6 @@ class DatasetsClient:
         self,
         *,
         name: str,
-        description: Optional[str] = None,
         schema: List[Dict[str, Any]],
     ) -> Dataset:
         """
@@ -187,7 +186,6 @@ class DatasetsClient:
 
         Args:
             name: Dataset name (required)
-            description: Dataset description (optional)
             schema: Dataset schema as a list of property dictionaries (required)
 
         Returns:
@@ -198,9 +196,6 @@ class DatasetsClient:
         """
         # Construct the basic dataset data
         data: Dict[str, Any] = {"name": name}
-
-        if description:
-            data["description"] = description
 
         # Process schema items
         processed_schema = []

--- a/tests/e2e/test_datasets.py
+++ b/tests/e2e/test_datasets.py
@@ -47,7 +47,6 @@ class TestDatasetBasicCRUDOperations:
         # Create a dataset using the new keyword-only parameters
         temp_dataset = client.datasets.create(
             name=create_unique_name("Temp Dataset"),
-            description="Temporary dataset for deletion test",
             schema=get_basic_schema(),
         )
 
@@ -87,7 +86,6 @@ class TestConversationSchemaType:
 
         dataset = client.datasets.create(
             name=create_unique_name("Conversation Dataset"),
-            description="Dataset with conversation type for testing",
             schema=conversation_schema,
         )
         dataset_id = dataset.external_id


### PR DESCRIPTION
This doesn't exist in the public api or dataset model

<!-- greptile_comment -->

## Greptile Summary

Removed the unused 'description' parameter from dataset creation functionality in the Python SDK to align with the public API and dataset model.

- Removed 'description' parameter from `DatasetsClient.create()` method in `/autoblocks/_impl/datasets/client.py`
- Removed 'description' parameter from dataset creation calls in `/tests/e2e/test_datasets.py`
- While `Dataset` model has an optional description field, it's not meant to be set during creation



<!-- /greptile_comment -->