### PR TITLE
EPD-1978: reads AUTOBLOCKS_OVERRIDES

### DIFF
--- a/autoblocks/_impl/datasets/util.py
+++ b/autoblocks/_impl/datasets/util.py
@@ -1,0 +1,12 @@
+from typing import List
+
+from autoblocks._impl.util import parse_autoblocks_overrides
+
+
+def get_selected_datasets() -> List[str]:
+    """
+    Gets the list of selected dataset external IDs from overrides.
+    Returns empty list if no datasets are selected or not in testing context.
+    """
+    overrides = parse_autoblocks_overrides()
+    return overrides.test_selected_datasets

--- a/autoblocks/_impl/prompts/manager.py
+++ b/autoblocks/_impl/prompts/manager.py
@@ -29,6 +29,7 @@ from autoblocks._impl.util import AnyTask
 from autoblocks._impl.util import AutoblocksEnvVar
 from autoblocks._impl.util import encode_uri_component
 from autoblocks._impl.util import get_running_loop
+from autoblocks._impl.util import parse_autoblocks_overrides
 
 log = logging.getLogger(__name__)
 
@@ -48,13 +49,19 @@ def is_testing_context() -> bool:
 
 def prompt_revisions_map() -> dict[str, str]:
     """
-    The AUTOBLOCKS_OVERRIDES_PROMPT_REVISIONS environment variable is a JSON-stringified
-    map of prompt IDs to revision IDs. This is set in CI test runs triggered
-    from the UI.
+    The AUTOBLOCKS_OVERRIDES environment variable is a JSON-stringified
+    object that can contain promptRevisions. This is set in CI test runs triggered
+    from the UI. Falls back to legacy AUTOBLOCKS_OVERRIDES_PROMPT_REVISIONS.
     """
     if not is_testing_context():
         return {}
 
+    # Try new unified format first
+    overrides = parse_autoblocks_overrides()
+    if overrides.prompt_revisions:
+        return overrides.prompt_revisions
+
+    # Fallback to legacy format
     prompt_revisions_raw = AutoblocksEnvVar.OVERRIDES_PROMPT_REVISIONS.get()
     if not prompt_revisions_raw:
         return {}

--- a/autoblocks/_impl/testing/run.py
+++ b/autoblocks/_impl/testing/run.py
@@ -42,6 +42,7 @@ from autoblocks._impl.testing.util import yield_test_case_contexts_from_test_cas
 from autoblocks._impl.util import AutoblocksEnvVar
 from autoblocks._impl.util import all_settled
 from autoblocks._impl.util import is_cli_running
+from autoblocks._impl.util import parse_autoblocks_overrides
 
 log = logging.getLogger(__name__)
 
@@ -364,9 +365,13 @@ async def run_test_suite_for_grid_combo(
     human_review_job: Optional[CreateHumanReviewJob],
 ) -> None:
     try:
+        # Determine message with priority: unified overrides > legacy env var
+        overrides = parse_autoblocks_overrides()
+        message = overrides.test_run_message or AutoblocksEnvVar.TEST_RUN_MESSAGE.get()
+
         run_id = await send_start_test_run(
             test_external_id=test_id,
-            message=AutoblocksEnvVar.TEST_RUN_MESSAGE.get(),
+            message=message,
             grid_search_run_group_id=grid_search_run_group_id,
             grid_search_params_combo=grid_search_params_combo,
         )

--- a/autoblocks/_impl/testing/run_manager.py
+++ b/autoblocks/_impl/testing/run_manager.py
@@ -17,6 +17,7 @@ from autoblocks._impl.testing.models import TestCaseContext
 from autoblocks._impl.testing.models import TestCaseType
 from autoblocks._impl.util import AutoblocksEnvVar
 from autoblocks._impl.util import all_settled
+from autoblocks._impl.util import parse_autoblocks_overrides
 
 log = logging.getLogger(__name__)
 
@@ -46,9 +47,15 @@ class RunManager(Generic[TestCaseType, OutputType]):
         # This can be called twice, so we put it in both the sync and async start methods to ensure it gets called
         global_state.init()
 
+        # Determine message with priority: explicit > unified overrides > legacy env var
+        message = self.message
+        if not message:
+            overrides = parse_autoblocks_overrides()
+            message = overrides.test_run_message or AutoblocksEnvVar.TEST_RUN_MESSAGE.get()
+
         self.run_id = await send_start_test_run(
             test_external_id=self.test_external_id,
-            message=self.message or AutoblocksEnvVar.TEST_RUN_MESSAGE.get(),
+            message=message,
             grid_search_run_group_id=None,
             grid_search_params_combo=None,
         )

--- a/autoblocks/_impl/testing/v2/run.py
+++ b/autoblocks/_impl/testing/v2/run.py
@@ -40,6 +40,7 @@ from autoblocks._impl.tracer.util import SpanAttribute
 from autoblocks._impl.util import AutoblocksEnvVar
 from autoblocks._impl.util import all_settled
 from autoblocks._impl.util import cuid_generator
+from autoblocks._impl.util import parse_autoblocks_overrides
 from autoblocks._impl.util import serialize
 
 log = logging.getLogger(__name__)
@@ -347,8 +348,13 @@ async def run_test_suite_for_grid_combo(
     grid_search_params_combo: Optional[GridSearchParamsCombo],
 ) -> None:
     run_id = cuid_generator()
+
+    # Determine message with priority: unified overrides > legacy env var
+    overrides = parse_autoblocks_overrides()
+    run_message = overrides.test_run_message or AutoblocksEnvVar.TEST_RUN_MESSAGE.get()
+
     test_run_reset_token = test_run_context_var.set(
-        TestRunContext(run_id=run_id, run_message=AutoblocksEnvVar.TEST_RUN_MESSAGE.get(), test_id=test_id)
+        TestRunContext(run_id=run_id, run_message=run_message, test_id=test_id)
     )
     grid_search_reset_token = (
         grid_search_context_var.set(grid_search_params_combo) if grid_search_params_combo else None

--- a/autoblocks/datasets/utils.py
+++ b/autoblocks/datasets/utils.py
@@ -1,0 +1,3 @@
+from autoblocks._impl.datasets.util import get_selected_datasets
+
+__all__ = ["get_selected_datasets"]


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR introduces a unified overrides system through `AUTOBLOCKS_OVERRIDES` environment variable, consolidating previously separate configuration settings for prompt revisions, test run messages, and dataset selection.

- Adds `parse_autoblocks_overrides()` in `autoblocks/_impl/util.py` to handle the new unified JSON format while maintaining backward compatibility
- Implements priority system in `autoblocks/_impl/prompts/manager.py` where unified format takes precedence over legacy `AUTOBLOCKS_OVERRIDES_PROMPT_REVISIONS`
- Adds new `get_selected_datasets()` utility in `autoblocks/_impl/datasets/util.py` to retrieve dataset IDs from overrides
- Updates test suite runners in both `testing/run.py` and `testing/v2/run.py` to use unified overrides for test run messages
- Comprehensive test coverage added in `tests/autoblocks/test_prompt_manager.py` verifying format precedence and edge cases



<!-- /greptile_comment -->