### PR TITLE
EPD-1997: add split filter to datasets.get_items

### DIFF
--- a/autoblocks/_impl/datasets/client.py
+++ b/autoblocks/_impl/datasets/client.py
@@ -137,7 +137,7 @@ class DatasetsClient(BaseAppResourceClient):
         if splits:
             query_params["splits"] = ",".join(splits)
 
-        path = self._build_app_path("datasets", external_id, "items", query_params=query_params)
+        path = self._build_app_path("datasets", external_id, "items", **query_params)
         response = self._make_request("GET", path)
         return deserialize_model_list(DatasetItem, response)
 
@@ -209,9 +209,7 @@ class DatasetsClient(BaseAppResourceClient):
         if splits:
             query_params["splits"] = ",".join(splits)
 
-        path = self._build_app_path(
-            "datasets", dataset_id, "revisions", revision_id, "items", query_params=query_params
-        )
+        path = self._build_app_path("datasets", dataset_id, "revisions", revision_id, "items", **query_params)
         response = self._make_request("GET", path)
         return deserialize_model_list(DatasetItem, response)
 
@@ -233,9 +231,7 @@ class DatasetsClient(BaseAppResourceClient):
         if splits:
             query_params["splits"] = ",".join(splits)
 
-        path = self._build_app_path(
-            "datasets", dataset_id, "schema", str(schema_version), "items", query_params=query_params
-        )
+        path = self._build_app_path("datasets", dataset_id, "schema", str(schema_version), "items", **query_params)
         response = self._make_request("GET", path)
         return deserialize_model_list(DatasetItem, response)
 

--- a/autoblocks/_impl/datasets/client.py
+++ b/autoblocks/_impl/datasets/client.py
@@ -115,12 +115,14 @@ class DatasetsClient(BaseAppResourceClient):
         self,
         *,
         external_id: str,
+        splits: Optional[List[str]] = None,
     ) -> List[DatasetItem]:
         """
         Get all items in a dataset.
 
         Args:
             external_id: Dataset ID (required)
+            splits: Optional list of splits to filter by
 
         Returns:
             List of dataset items
@@ -131,7 +133,11 @@ class DatasetsClient(BaseAppResourceClient):
         if not external_id:
             raise ValidationError("Dataset ID is required")
 
-        path = self._build_app_path("datasets", external_id, "items")
+        query_params: Dict[str, Any] = {}
+        if splits:
+            query_params["splits"] = ",".join(splits)
+
+        path = self._build_app_path("datasets", external_id, "items", query_params=query_params)
         response = self._make_request("GET", path)
         return deserialize_model_list(DatasetItem, response)
 

--- a/tests/e2e/test_app_client.py
+++ b/tests/e2e/test_app_client.py
@@ -78,6 +78,11 @@ class TestAutoblocksAppClient:
         assert len(retrieved_items) == 1
         assert retrieved_items[0].data["Text Field"] == "Sample text"
 
+        # Test splits filtering
+        train_items = client.datasets.get_items(external_id=dataset.external_id, splits=["train"])
+        assert len(train_items) == 1
+        assert "train" in train_items[0].splits
+
         # Update item
         update_data = {
             "Text Field": "Updated text",

--- a/tests/e2e/test_datasets.py
+++ b/tests/e2e/test_datasets.py
@@ -275,11 +275,14 @@ class TestDatasetItemsOperations:
 
         # Test splits filtering
         train_items: List[DatasetItem] = client.datasets.get_items(external_id=test_dataset_id, splits=["train"])
+
         assert len(train_items) == 2
+
         for item in train_items:
             assert "train" in item.splits
 
         test_items: List[DatasetItem] = client.datasets.get_items(external_id=test_dataset_id, splits=["test"])
+
         assert len(test_items) == 2
         for item in test_items:
             assert "test" in item.splits

--- a/tests/e2e/test_datasets.py
+++ b/tests/e2e/test_datasets.py
@@ -151,6 +151,23 @@ class TestConversationSchemaType:
         assert len(retrieved_items) == 1
         assert retrieved_items[0].data["title"] == "Sample conversation"
 
+        # Test splits filtering
+        train_items: List[DatasetItem] = client.datasets.get_items(
+            external_id=conversation_dataset_id, splits=["train"]
+        )
+        assert len(train_items) == 1
+        assert "train" in train_items[0].splits
+
+        test_items: List[DatasetItem] = client.datasets.get_items(external_id=conversation_dataset_id, splits=["test"])
+        assert len(test_items) == 1
+        assert "test" in test_items[0].splits
+
+        # Test filtering by multiple splits
+        train_test_items: List[DatasetItem] = client.datasets.get_items(
+            external_id=conversation_dataset_id, splits=["train", "test"]
+        )
+        assert len(train_test_items) == 1
+
         # Since conversation is stored as JSON, compare the structure
         assert "conversation" in retrieved_items[0].data
 
@@ -232,11 +249,57 @@ class TestDatasetItemsOperations:
         assert create_items_result.count == 2
         assert create_items_result.revision_id is not None
 
+        # Add additional items with different splits for testing splits filtering
+        additional_items = [
+            {
+                "Text Field": "Validation text 1",
+                "Number Field": 100,
+            },
+            {
+                "Text Field": "Validation text 2",
+                "Number Field": 101,
+            },
+        ]
+
+        validation_result = client.datasets.create_items(
+            external_id=test_dataset_id, items=additional_items, split_names=["validation"]
+        )
+
+        assert validation_result.count == 2
+
     def test_retrieve_items_from_dataset(self, client: AutoblocksAppClient, test_dataset_id: str) -> None:
         """Test retrieving items from the dataset."""
         retrieved_items: List[DatasetItem] = client.datasets.get_items(external_id=test_dataset_id)
 
-        assert len(retrieved_items) == 2
+        assert len(retrieved_items) == 4  # 2 train/test items + 2 validation items
+
+        # Test splits filtering
+        train_items: List[DatasetItem] = client.datasets.get_items(external_id=test_dataset_id, splits=["train"])
+        assert len(train_items) == 2
+        for item in train_items:
+            assert "train" in item.splits
+
+        test_items: List[DatasetItem] = client.datasets.get_items(external_id=test_dataset_id, splits=["test"])
+        assert len(test_items) == 2
+        for item in test_items:
+            assert "test" in item.splits
+
+        validation_items: List[DatasetItem] = client.datasets.get_items(
+            external_id=test_dataset_id, splits=["validation"]
+        )
+        assert len(validation_items) == 2
+        for item in validation_items:
+            assert "validation" in item.splits
+
+        # Test filtering by multiple splits
+        train_test_items: List[DatasetItem] = client.datasets.get_items(
+            external_id=test_dataset_id, splits=["train", "test"]
+        )
+        assert len(train_test_items) == 2  # Items that have both train AND test splits
+
+        # Test filtering with non-existent split
+        empty_items: List[DatasetItem] = client.datasets.get_items(external_id=test_dataset_id, splits=["nonexistent"])
+        assert len(empty_items) == 0
 
         # Store an item ID for update/delete tests in the class variable
         TestDatasetItemsOperations.test_item_id = retrieved_items[0].id


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Added split filtering functionality to the `datasets.get_items` method, allowing filtering of dataset items by specified splits. The implementation aligns with existing methods and includes comprehensive testing.

- Added optional `splits` parameter to `get_items` method in `/autoblocks/_impl/datasets/client.py`
- Added test coverage for split filtering in `/tests/e2e/test_app_client.py` verifying basic functionality
- Implemented comprehensive split filtering tests in `/tests/e2e/test_datasets.py` covering single splits, multiple splits, and edge cases
- Tests verify split assignments are preserved during item updates and handle non-existent splits correctly



<!-- /greptile_comment -->