### PR TITLE
Allow empty messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,7 @@ jobs:
         run: npx --package renovate renovate-config-validator --strict
 
   tests:
-    runs-on:
-      - codebuild-autoblocksai-${{ github.run_id }}-${{ github.run_attempt }}
-      - instance-size:small
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     strategy:
@@ -77,9 +75,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          export PATH="/root/.local/bin:$PATH"
+        run: curl -sSL https://install.python-poetry.org | python3 -
 
       - name: Check pyproject.toml & poetry.lock are in sync
         run: poetry check --lock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install poetry
-        run: curl -sSL https://install.python-poetry.org | python3 -
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          export PATH="/root/.local/bin:$PATH"
 
       - name: Check pyproject.toml & poetry.lock are in sync
         run: poetry check --lock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,9 @@ jobs:
         run: npx --package renovate renovate-config-validator --strict
 
   tests:
-    runs-on: ubuntu-latest
+    runs-on:
+      - codebuild-autoblocksai-${{ github.run_id }}-${{ github.run_attempt }}
+      - instance-size:small
     timeout-minutes: 15
 
     strategy:

--- a/autoblocks/_impl/scenarios/client.py
+++ b/autoblocks/_impl/scenarios/client.py
@@ -52,8 +52,6 @@ class ScenariosClient(BaseAppResourceClient):
         """
         if not scenario_id:
             raise ValidationError("Scenario ID is required")
-        if not messages:
-            raise ValidationError("Messages list cannot be empty")
 
         # Prepare data payload
         data: Dict[str, Any] = {"messages": [serialize_model(message) for message in messages]}


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Removes validation that enforces non-empty message lists in `autoblocks/_impl/scenarios/client.py`, allowing empty message arrays to be passed to `generate_message` method while maintaining scenario_id validation.

- Potential risk: Downstream components or API may expect at least one message, making this change potentially breaking
- Consider adding documentation or test cases to clarify intended behavior with empty message lists
- Review API specifications to ensure empty messages are supported at the backend level



<!-- /greptile_comment -->