### PR TITLE
EPD-2029: update to match API changesS

### DIFF
--- a/autoblocks/_impl/datasets/client.py
+++ b/autoblocks/_impl/datasets/client.py
@@ -15,7 +15,6 @@ from autoblocks._impl.api.utils.serialization import serialize_model
 from autoblocks._impl.datasets.models.dataset import Dataset
 from autoblocks._impl.datasets.models.dataset import DatasetItem
 from autoblocks._impl.datasets.models.dataset import DatasetItemsSuccessResponse
-from autoblocks._impl.datasets.models.dataset import DatasetListItem
 from autoblocks._impl.datasets.models.dataset import DatasetSchema
 from autoblocks._impl.datasets.models.dataset import SuccessResponse
 from autoblocks._impl.datasets.models.schema import create_schema_property
@@ -30,7 +29,7 @@ class DatasetsClient(BaseAppResourceClient):
     def __init__(self, app_slug: str, api_key: str, timeout: timedelta = timedelta(seconds=60)) -> None:
         super().__init__(app_slug=app_slug, api_key=api_key, timeout=timeout)
 
-    def list(self) -> List[DatasetListItem]:
+    def list(self) -> List[Dataset]:
         """
         List all datasets in the app.
 
@@ -39,7 +38,7 @@ class DatasetsClient(BaseAppResourceClient):
         """
         path = self._build_app_path("datasets")
         response = self._make_request("GET", path)
-        return deserialize_model_list(DatasetListItem, response)
+        return deserialize_model_list(Dataset, response)
 
     def create(
         self,

--- a/autoblocks/_impl/datasets/models/dataset.py
+++ b/autoblocks/_impl/datasets/models/dataset.py
@@ -36,26 +36,12 @@ class Dataset(BaseModel):
     )
 
 
-class DatasetListItem(BaseModel):
-    """Dataset list item V2"""
-
-    id: str
-    external_id: str = Field(alias="externalId")
-    name: Optional[str] = None
-    latest_revision_id: Optional[str] = Field(default=None, alias="latestRevisionId")
-    schema_version: Optional[int] = Field(default=None, alias="schemaVersion")
-    schema_properties: Optional[List[SchemaProperty]] = Field(default=None, alias="schema")
-
-    model_config = ConfigDict(
-        populate_by_name=True,
-        extra="allow",
-    )
-
-
 class DatasetSchema(BaseModel):
     """Dataset schema V2"""
 
     id: str
+    name: Optional[str] = None
+    latest_revision_id: Optional[str] = Field(default=None, alias="latestRevisionId")
     external_id: str = Field(alias="externalId")
     schema_properties: Optional[List[SchemaProperty]] = Field(default=None, alias="schema")
     schema_version: int = Field(alias="schemaVersion")

--- a/autoblocks/datasets/models.py
+++ b/autoblocks/datasets/models.py
@@ -8,7 +8,6 @@ from autoblocks._impl.datasets.models.dataset import CreateDatasetRequest
 from autoblocks._impl.datasets.models.dataset import Dataset
 from autoblocks._impl.datasets.models.dataset import DatasetItem
 from autoblocks._impl.datasets.models.dataset import DatasetItemsSuccessResponse
-from autoblocks._impl.datasets.models.dataset import DatasetListItem
 from autoblocks._impl.datasets.models.dataset import DatasetSchema
 from autoblocks._impl.datasets.models.dataset import SuccessResponse
 from autoblocks._impl.datasets.models.dataset import UpdateItemRequest
@@ -35,7 +34,6 @@ __all__ = [
     "Dataset",
     "DatasetItem",
     "DatasetItemsSuccessResponse",
-    "DatasetListItem",
     "DatasetSchema",
     "ListOfStringsProperty",
     "MultiSelectProperty",

--- a/tests/e2e/test_datasets.py
+++ b/tests/e2e/test_datasets.py
@@ -255,7 +255,7 @@ class TestDatasetItemsOperations:
             external_id=test_dataset_id, items=items, split_names=["train", "test"]
         )
 
-        assert create_items_result.count == 2
+        assert create_items_result.count == 2  # Total items in dataset after first creation
         assert create_items_result.revision_id is not None
 
         # Verify that creating items created a new dataset revision
@@ -281,8 +281,9 @@ class TestDatasetItemsOperations:
             external_id=test_dataset_id, items=additional_items, split_names=["validation"]
         )
 
-        assert validation_result.count == 2
+        assert validation_result.count == 4  # Total items in dataset (2 + 2)
         assert validation_result.revision_id is not None
+        assert validation_result.revision_id != create_items_result.revision_id
 
         # Verify that adding more items created another new revision
         final_datasets = client.datasets.list()


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updates the Python SDK to align with API changes, simplifying dataset models by removing `DatasetListItem` and consolidating around the `Dataset` model for consistent response types.

- Modified `autoblocks/_impl/datasets/client.py` to use `List[Dataset]` instead of `List[DatasetListItem]` for list() method returns
- Added `name` and `latest_revision_id` fields to `DatasetSchema` class in `autoblocks/_impl/datasets/models/dataset.py`
- Enhanced test coverage in `tests/e2e/test_datasets.py` with revision tracking and type safety verifications
- Simplified public API by removing `DatasetListItem` from `autoblocks/datasets/models.py`



<!-- /greptile_comment -->