### PR TITLE
EPD-2117: add run_manager for V2

### DIFF
--- a/autoblocks/_impl/testing/v2/run.py
+++ b/autoblocks/_impl/testing/v2/run.py
@@ -123,7 +123,7 @@ async def run_evaluator_unsafe(
     This is suffixed with _unsafe because it doesn't handle exceptions.
     Its caller will catch and handle all exceptions.
     """
-    evaluation: Optional[Evaluation] | Awaitable[Optional[Evaluation]] = None
+    evaluation: Union[Optional[Evaluation], Awaitable[Optional[Evaluation]]] = None
     async with evaluator_semaphore_registry[test_id][evaluator.id]:
         if hook_results is not None:
             kwargs = dict(hook_results=hook_results)
@@ -159,7 +159,7 @@ async def run_evaluator(
     reset_token = evaluator_run_context_var.set(
         EvaluatorRunContext(),
     )
-    evaluation: Evaluation | None = None
+    evaluation: Optional[Evaluation] = None
     try:
         evaluation = await run_evaluator_unsafe(
             test_id=test_id,

--- a/autoblocks/_impl/testing/v2/run.py
+++ b/autoblocks/_impl/testing/v2/run.py
@@ -464,11 +464,11 @@ async def run_test_suite_for_grid_combo(
     )
 
     try:
-        notifications = [
-            send_v2_slack_notification(run_id=run_id, app_slug=app_slug),
-        ]
+        notifications = []
+
         if build_id:
-            notifications.append(send_v2_github_comment(app_slug=app_slug, build_id=build_id))
+            notifications.append(send_v2_slack_notification(run_id=run_id, app_slug=app_slug, build_id=build_id))
+            notifications.append(send_v2_github_comment(run_id=run_id, app_slug=app_slug, build_id=build_id))
 
         await all_settled(notifications)
         log.debug(f"V2 notification dispatch completed for test run '{run_id}' with app_slug '{app_slug}'")

--- a/autoblocks/_impl/testing/v2/run_manager.py
+++ b/autoblocks/_impl/testing/v2/run_manager.py
@@ -1,0 +1,251 @@
+import asyncio
+import json
+import logging
+from typing import Any
+from typing import List
+from typing import Optional
+from typing import Sequence
+
+from autoblocks._impl import global_state
+from autoblocks._impl.testing.models import BaseTestCase
+from autoblocks._impl.testing.models import BaseTestEvaluator
+from autoblocks._impl.testing.models import Evaluation
+from autoblocks._impl.testing.models import EvaluationWithId
+from autoblocks._impl.testing.models import TestCaseContext
+from autoblocks._impl.testing.util import serialize_output
+from autoblocks._impl.testing.util import serialize_test_case
+from autoblocks._impl.testing.v2.api import send_create_human_review_job
+from autoblocks._impl.testing.v2.api import send_create_result
+from autoblocks._impl.testing.v2.run import run_evaluator
+from autoblocks._impl.util import all_settled
+from autoblocks._impl.util import cuid_generator
+from autoblocks._impl.util import now_rfc3339
+from autoblocks._impl.util import serialize_to_string
+
+log = logging.getLogger(__name__)
+
+
+class RunManager:
+    """
+    Manual-only run manager for V2.
+
+    Lifecycle:
+      - start(): mark start timestamp (no network)
+      - add_result(): compute evaluations locally, POST a single composite result
+      - end(): mark end timestamp and allow human review creation
+      - create_human_review(): create HR job using start/end timestamps
+    """
+
+    def __init__(self, app_slug: str, environment: str = "test", run_message: Optional[str] = None):
+        self.app_slug = app_slug
+        self.environment = environment
+        self.run_message = run_message
+
+        self.run_id: str = cuid_generator()
+        self.started_at: Optional[str] = None
+        self.ended_at: Optional[str] = None
+        self.can_create_human_review: bool = False
+
+    async def async_start(self) -> None:
+        global_state.init()
+        self.started_at = now_rfc3339()
+
+    def start(self) -> None:
+        global_state.init()
+        asyncio.run_coroutine_threadsafe(self.async_start(), global_state.event_loop()).result()
+
+    async def _compute_evaluations(
+        self,
+        *,
+        test_case_ctx: TestCaseContext[BaseTestCase],
+        output: Any,
+        evaluators: Sequence[BaseTestEvaluator] | None,
+    ) -> List[EvaluationWithId]:
+        if not evaluators:
+            return []
+        results = await all_settled(
+            [
+                run_evaluator(
+                    test_id=self.app_slug,  # use app_slug as the suite identifier for semaphore scoping
+                    test_case_ctx=test_case_ctx,
+                    output=output,
+                    hook_results=None,
+                    evaluator=evaluator,
+                )
+                for evaluator in evaluators
+            ]
+        )
+
+        evaluations: List[EvaluationWithId] = []
+        for value in results:
+            if isinstance(value, EvaluationWithId):
+                evaluations.append(value)
+            elif isinstance(value, Exception):
+                log.error("Evaluator execution failed", exc_info=value)
+        return evaluations
+
+    @staticmethod
+    def _evaluations_to_maps(
+        evals: List[EvaluationWithId],
+    ) -> tuple[dict[str, bool], dict[str, str], dict[str, float]]:
+        id_to_result: dict[str, bool] = {}
+        id_to_reason: dict[str, str] = {}
+        id_to_score: dict[str, float] = {}
+
+        for e in evals:
+            # Reconstruct Evaluation to compute passed()
+            evaluation = Evaluation(
+                score=e.score,
+                threshold=e.threshold,
+                metadata=e.metadata,
+                assertions=e.assertions,
+            )
+
+            # Passed/failed
+            # Evaluation.passed() may be None if no threshold comparisons apply; coerce to bool for API
+            id_to_result[e.id] = bool(evaluation.passed())
+
+            # Reason selection: metadata.reason > first failing assertion > ''
+            reason: str = ""
+
+            if evaluation.metadata and isinstance(evaluation.metadata, dict):
+                maybe_reason = evaluation.metadata.get("reason")
+
+                if isinstance(maybe_reason, str) and maybe_reason:
+                    reason = maybe_reason
+            if not reason and evaluation.assertions:
+                for a in evaluation.assertions:
+                    if not a.passed:
+                        # V2 Assertion has no `message` attribute; prefer metadata fields if present
+                        metadata = a.metadata or {}
+                        maybe_msg = metadata.get("message") or metadata.get("reason")
+                        reason = maybe_msg if isinstance(maybe_msg, str) else ""
+                        if reason:
+                            break
+
+            id_to_reason[e.id] = reason
+            id_to_score[e.id] = e.score
+        return id_to_result, id_to_reason, id_to_score
+
+    async def async_add_result(
+        self,
+        *,
+        test_case: BaseTestCase,
+        output: Any,
+        duration_ms: float,
+        evaluators: Optional[Sequence[BaseTestEvaluator]] = None,
+        status: str = "SUCCESS",
+        started_at: Optional[str] = None,
+    ) -> str:
+        if self.ended_at:
+            raise ValueError("You cannot add results to an ended run.")
+
+        global_state.init()
+        # Build test case context
+        test_case_ctx = TestCaseContext(test_case=test_case, repetition_idx=None)
+
+        # Compute evaluations like the OTEL path
+        evals = await self._compute_evaluations(
+            test_case_ctx=test_case_ctx,
+            output=output,
+            evaluators=evaluators or [],
+        )
+        eval_result_map, eval_reason_map, eval_score_map = self._evaluations_to_maps(evals)
+
+        # Serialize input/output
+        input_raw = serialize_to_string(serialize_test_case(test_case))
+        output_raw = serialize_to_string(serialize_output(output))
+
+        # Per-execution start time defaults to now if not provided
+        exec_started_at = started_at or now_rfc3339()
+
+        # POST composite result
+        resp = await send_create_result(
+            app_slug=self.app_slug,
+            run_id=self.run_id,
+            environment=self.environment,
+            started_at=exec_started_at,
+            duration_ms=duration_ms,
+            status=status,
+            input_raw=input_raw,
+            output_raw=output_raw,
+            input_map=json.loads(input_raw),
+            output_map=json.loads(output_raw),
+            evaluator_id_to_result=eval_result_map,
+            evaluator_id_to_reason=eval_reason_map,
+            evaluator_id_to_score=eval_score_map,
+            run_message=self.run_message,
+        )
+        data = resp.json()
+        execution_id = data["executionId"]
+        # Ensure we return a string
+        return str(execution_id)
+
+    def add_result(
+        self,
+        *,
+        test_case: BaseTestCase,
+        output: Any,
+        duration_ms: float,
+        evaluators: Optional[Sequence[BaseTestEvaluator]] = None,
+        status: str = "SUCCESS",
+        metadata: Optional[dict[str, str]] = None,
+        started_at: Optional[str] = None,
+    ) -> str:
+        return asyncio.run_coroutine_threadsafe(
+            self.async_add_result(
+                test_case=test_case,
+                output=output,
+                duration_ms=duration_ms,
+                evaluators=evaluators,
+                status=status,
+                started_at=started_at,
+            ),
+            global_state.event_loop(),
+        ).result()
+
+    async def async_end(self) -> None:
+        if not self.started_at:
+            # Still allow end(), but set a start timestamp to keep HR window valid
+            self.started_at = now_rfc3339()
+        self.ended_at = now_rfc3339()
+        self.can_create_human_review = True
+
+    def end(self) -> None:
+        asyncio.run_coroutine_threadsafe(self.async_end(), global_state.event_loop()).result()
+
+    async def async_create_human_review(
+        self,
+        *,
+        name: str,
+        assignee_email_addresses: List[str],
+        rubric_id: Optional[str] = None,
+    ) -> None:
+        if not self.can_create_human_review or not self.started_at or not self.ended_at:
+            raise ValueError("Run has not ended or timestamps missing; call end() before creating human review.")
+
+        await send_create_human_review_job(
+            run_id=self.run_id,
+            app_slug=self.app_slug,
+            start_timestamp=self.started_at,
+            end_timestamp=self.ended_at,
+            assignee_email_addresses=assignee_email_addresses,
+            name=name,
+            rubric_id=rubric_id,
+        )
+
+    def create_human_review(
+        self,
+        *,
+        name: str,
+        assignee_email_addresses: List[str],
+        rubric_id: Optional[str] = None,
+    ) -> None:
+        asyncio.run_coroutine_threadsafe(
+            self.async_create_human_review(
+                name=name,
+                assignee_email_addresses=assignee_email_addresses,
+                rubric_id=rubric_id,
+            ),
+            global_state.event_loop(),
+        ).result()

--- a/tests/autoblocks/test_run_manager_v2.py
+++ b/tests/autoblocks/test_run_manager_v2.py
@@ -3,6 +3,7 @@ import os
 from dataclasses import dataclass
 from typing import Any
 from typing import List
+from typing import Optional
 from unittest import mock
 
 import pytest
@@ -55,7 +56,7 @@ class MyEvaluator(BaseTestEvaluator):
     def id(self) -> str:
         return "evaluator-external-id"
 
-    def evaluate_test_case(self, *args: Any, **kwargs: Any) -> Evaluation | None:
+    def evaluate_test_case(self, *args: Any, **kwargs: Any) -> Optional[Evaluation]:
         return Evaluation(score=1, threshold=Threshold(gte=0.5), metadata={"reason": "ok"})
 
 

--- a/tests/autoblocks/test_run_manager_v2.py
+++ b/tests/autoblocks/test_run_manager_v2.py
@@ -1,0 +1,193 @@
+import json
+import os
+from dataclasses import dataclass
+from typing import Any
+from typing import List
+from unittest import mock
+
+import pytest
+
+from autoblocks._impl.config.constants import API_ENDPOINT_V2
+from autoblocks._impl.testing.models import BaseTestCase
+from autoblocks._impl.testing.models import BaseTestEvaluator
+from autoblocks._impl.testing.models import Evaluation
+from autoblocks._impl.testing.models import HumanReviewField
+from autoblocks._impl.testing.models import HumanReviewFieldContentType
+from autoblocks._impl.testing.models import Threshold
+from autoblocks._impl.testing.v2.run_manager import RunManager
+from autoblocks._impl.util import AutoblocksEnvVar
+from tests.util import ANY_STRING
+
+
+@pytest.fixture(autouse=True)
+def mock_env_var():
+    with mock.patch.dict(
+        os.environ,
+        {
+            AutoblocksEnvVar.V2_API_KEY.value: "mock-api-key",
+            "CI": "false",
+        },
+    ):
+        yield
+
+
+@dataclass
+class MyTestCase(BaseTestCase):
+    input: str
+
+    def hash(self) -> str:
+        return self.input
+
+    def serialize_for_human_review(self) -> List[HumanReviewField]:
+        return [HumanReviewField(name="input", value=self.input, content_type=HumanReviewFieldContentType.TEXT)]
+
+
+@dataclass
+class MyOutput:
+    output: str
+
+    def serialize_for_human_review(self) -> List[HumanReviewField]:
+        return [HumanReviewField(name="output", value=self.output, content_type=HumanReviewFieldContentType.TEXT)]
+
+
+class MyEvaluator(BaseTestEvaluator):
+    @property
+    def id(self) -> str:
+        return "evaluator-external-id"
+
+    def evaluate_test_case(self, *args: Any, **kwargs: Any) -> Evaluation | None:
+        return Evaluation(score=1, threshold=Threshold(gte=0.5), metadata={"reason": "ok"})
+
+
+def test_does_not_allow_adding_result_after_run_has_ended_v2():
+    test_run = RunManager(app_slug="my-app", run_message="Test run")
+
+    test_run.start()
+    test_run.end()
+
+    with pytest.raises(ValueError):
+        test_run.add_result(
+            test_case=MyTestCase(input="test"),
+            output=MyOutput(output="test"),
+            duration_ms=100,
+        )
+
+
+def test_full_lifecycle_v2(httpx_mock):
+    # Expect composite result POST
+    httpx_mock.add_response(
+        url=f"{API_ENDPOINT_V2}/testing/results",
+        method="POST",
+        match_json=dict(
+            appSlug="my-app",
+            runId=ANY_STRING,
+            environment="test",
+            runMessage="Test run",
+            startedAt="2025-01-01T00:00:00.000Z",
+            durationMS=100,
+            status="SUCCESS",
+            inputRaw=json.dumps({"input": "test"}),
+            outputRaw=json.dumps({"output": "test"}),
+            input={"input": "test"},
+            output={"output": "test"},
+            evaluatorIdToResult={"evaluator-external-id": True},
+            evaluatorIdToReason={"evaluator-external-id": "ok"},
+            evaluatorIdToScore={"evaluator-external-id": 1},
+        ),
+        json=dict(executionId="mock-exec-id"),
+    )
+
+    # Expect HR job POST
+    httpx_mock.add_response(
+        url=f"{API_ENDPOINT_V2}/apps/my-app/human-review/jobs",
+        method="POST",
+        match_json=dict(
+            runId=ANY_STRING,
+            startTimestamp=ANY_STRING,
+            endTimestamp=ANY_STRING,
+            rubricId=None,
+            assigneeEmailAddresses=["test@test.com"],
+            name="Test human review job",
+        ),
+        json=dict(),
+    )
+
+    test_run = RunManager(app_slug="my-app", run_message="Test run")
+
+    test_run.start()
+    exec_id = test_run.add_result(
+        test_case=MyTestCase(input="test"),
+        output=MyOutput(output="test"),
+        duration_ms=100,
+        evaluators=[MyEvaluator()],
+        started_at="2025-01-01T00:00:00.000Z",
+    )
+    assert exec_id == "mock-exec-id"
+
+    test_run.end()
+    test_run.create_human_review(
+        name="Test human review job",
+        assignee_email_addresses=["test@test.com"],
+    )
+
+
+def test_end_without_start_sets_timestamps_and_allows_human_review(httpx_mock):
+    httpx_mock.add_response(
+        url=f"{API_ENDPOINT_V2}/apps/my-app/human-review/jobs",
+        method="POST",
+        match_json=dict(
+            runId=ANY_STRING,
+            startTimestamp=ANY_STRING,
+            endTimestamp=ANY_STRING,
+            rubricId=None,
+            assigneeEmailAddresses=["a@test.com"],
+            name="HR job",
+        ),
+        json=dict(),
+    )
+
+    test_run = RunManager(app_slug="my-app")
+
+    # end() should backfill start timestamp and allow HR creation
+    test_run.end()
+    assert test_run.can_create_human_review is True
+    assert test_run.started_at is not None
+    assert test_run.ended_at is not None
+
+    test_run.create_human_review(
+        name="HR job",
+        assignee_email_addresses=["a@test.com"],
+    )
+
+
+def test_add_result_without_evaluators_sends_empty_maps(httpx_mock):
+    httpx_mock.add_response(
+        url=f"{API_ENDPOINT_V2}/testing/results",
+        method="POST",
+        match_json=dict(
+            appSlug="my-app",
+            runId=ANY_STRING,
+            environment="test",
+            runMessage=None,
+            startedAt=ANY_STRING,
+            durationMS=250,
+            status="SUCCESS",
+            inputRaw=json.dumps({"input": "test"}),
+            outputRaw=json.dumps({"output": "test"}),
+            input={"input": "test"},
+            output={"output": "test"},
+            evaluatorIdToResult={},
+            evaluatorIdToReason={},
+            evaluatorIdToScore={},
+        ),
+        json=dict(executionId="exec-1"),
+    )
+
+    test_run = RunManager(app_slug="my-app")
+    test_run.start()
+    exec_id = test_run.add_result(
+        test_case=MyTestCase(input="test"),
+        output=MyOutput(output="test"),
+        duration_ms=250,
+    )
+    assert exec_id == "exec-1"


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR introduces a complete V2 implementation of the RunManager testing infrastructure, representing a significant architectural evolution from V1. The key changes include:

**New V2 RunManager Implementation** (`autoblocks/_impl/testing/v2/run_manager.py`): Creates a manual-only lifecycle management system that generates run IDs locally using `cuid_generator()` instead of server-side generation. Unlike V1's server-coordinated approach, V2 uses a client-coordinated lifecycle with local evaluation computation and composite result submission via single API calls.

**Enhanced V2 API Layer** (`autoblocks/_impl/testing/v2/api.py`): Updates the API infrastructure by removing CLI-specific logic (indicating V2 is purely API-based), adding a new `send_create_result` function for comprehensive test result submission, and enhancing notification functions with additional parameters like `build_id` and `use_simple_format` for more granular control.

**Improved Notification Logic** (`autoblocks/_impl/testing/v2/run.py`): Standardizes notification behavior by making both Slack and GitHub notifications conditional on `build_id` presence, ensuring notifications only fire in CI environments rather than local development runs.

**Comprehensive Test Coverage** (`tests/autoblocks/test_run_manager_v2.py`): Implements thorough unit tests for the V2 RunManager using `httpx_mock` to validate the new API contract, including edge cases like timestamp backfilling when `end()` is called before `start()` and proper handling of empty evaluator maps.

The V2 architecture shifts from V1's multiple separate API calls to a streamlined single composite result API call pattern, improving performance while maintaining the familiar async/sync dual method patterns. The changes also introduce expanded human review capabilities with support for multiple assignee emails and rubric IDs, and more flexible usage patterns that allow ending runs without explicit start calls.

## Confidence score: 3/5

- This PR introduces significant architectural changes that require careful review due to the complexity of the new V2 testing system
- Score reflects concerns about manual query string construction in notifications and the substantial changes to core testing infrastructure
- Pay close attention to `autoblocks/_impl/testing/v2/api.py` for potential security issues with query string construction

<!-- /greptile_comment -->