### PR TITLE
Enable log message for all envs

### DIFF
--- a/autoblocks/_impl/testing/v2/run.py
+++ b/autoblocks/_impl/testing/v2/run.py
@@ -54,7 +54,6 @@ from autoblocks._impl.tracer.util import SpanAttribute
 from autoblocks._impl.util import AutoblocksEnvVar
 from autoblocks._impl.util import all_settled
 from autoblocks._impl.util import cuid_generator
-from autoblocks._impl.util import is_ci
 from autoblocks._impl.util import now_rfc3339
 from autoblocks._impl.util import parse_autoblocks_overrides
 from autoblocks._impl.util import serialize_to_string
@@ -420,10 +419,9 @@ async def run_test_suite_for_grid_combo(
     log.info(f"Running test suite '{test_id}' with {len(test_cases)} test cases")
 
     # Log URL to test results in GitHub CI (before tests start)
-    if is_ci():
-        timestamp = quote(start_timestamp, safe="")
-        url = f"{PUBLIC_WEBAPP_UI_URL}/apps/{app_id}/runs/inspect-run?baselineRunId={run_id}&startTimestamp={timestamp}"
-        print(f"View test results at: {url}")
+    timestamp = quote(start_timestamp, safe="")
+    url = f"{PUBLIC_WEBAPP_UI_URL}/apps/{app_id}/runs/inspect-run?baselineRunId={run_id}&startTimestamp={timestamp}"
+    print(f"View test results at: {url}")
 
     # Determine message with priority: unified overrides > legacy env var
     overrides = parse_autoblocks_overrides()


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-11 12:47:56 UTC

This PR removes the CI environment check that previously restricted test results URL logging to only CI environments. The change affects the `autoblocks/_impl/testing/v2/run.py` file by removing the import of the `is_ci` utility function and the conditional check that wrapped the URL printing logic.

Previously, when running tests, the "View test results at: {url}" message was only displayed when the `is_ci()` function returned true, meaning developers running tests locally wouldn't see the URL to access their test results in the Autoblocks web interface. Now, this URL will be printed unconditionally in all environments where tests are executed.

This change integrates well with the existing testing infrastructure. The URL generation logic remains unchanged - it still constructs a properly formatted URL pointing to the Autoblocks web interface with the appropriate app ID, run ID, and timestamp parameters. The only modification is removing the environment-based restriction, making the user experience consistent across local development, CI pipelines, and other execution contexts.

The change aligns with improving developer experience by ensuring that regardless of where tests are run (locally via `pytest`, in GitHub Actions CI, or other environments), users will always have easy access to view their detailed test results through the web interface.

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as it only removes a conditional check without altering core functionality
- Score reflects a simple, low-risk change that improves user experience without introducing breaking changes or complex logic modifications
- No files require special attention as the change is straightforward and contained to a single location

<!-- /greptile_comment -->