### PR TITLE
Support optional run_id

### DIFF
--- a/autoblocks/_impl/testing/v2/run.py
+++ b/autoblocks/_impl/testing/v2/run.py
@@ -659,11 +659,7 @@ def run_test_suite(
         log.debug(
             f"CUID2 validation failed for run_id: '{run_id}' " f"(length: {len(run_id)}, expected: {CUID2_LENGTH})"
         )
-        raise ValueError(
-            f"Invalid run_id: '{run_id}'. Must be a valid CUID2 "
-            f"({CUID2_LENGTH} lowercase alphanumeric characters). "
-            f"Got {len(run_id)} characters."
-        )
+        raise ValueError(f"Invalid run_id: '{run_id}'. Must be a valid CUID2.")
 
     global_state.init()
 

--- a/autoblocks/_impl/util.py
+++ b/autoblocks/_impl/util.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import re
 import traceback
 import urllib.parse
 from concurrent.futures import Future
@@ -63,6 +64,29 @@ def parse_autoblocks_overrides() -> AutoblocksOverrides:
 AnyTask = Union[asyncio.Task[Any], Future[Any]]
 
 cuid_generator = cuid_wrapper()
+
+# CUID2 validation constants
+CUID2_LENGTH = 24
+CUID2_CHARSET = "a-z0-9"
+_CUID2_PATTERN = re.compile(f"^[{CUID2_CHARSET}]{{{CUID2_LENGTH}}}$")
+
+
+def is_valid_cuid2(cuid: str) -> bool:
+    """
+    Validate if a string is a valid CUID2.
+
+    CUID2s are 24-character strings containing only lowercase letters and numbers.
+    This function uses a pre-compiled regex pattern for optimal performance.
+
+    Args:
+        cuid: The string to validate
+
+    Returns:
+        True if the string is a valid CUID2, False otherwise
+    """
+    if not isinstance(cuid, str):
+        return False
+    return bool(_CUID2_PATTERN.match(cuid))
 
 
 class StrEnum(str, Enum):

--- a/tests/autoblocks/test_cuid2_validation_performance.py
+++ b/tests/autoblocks/test_cuid2_validation_performance.py
@@ -1,0 +1,81 @@
+"""Performance tests for CUID2 validation."""
+
+import time
+
+import pytest
+from cuid2 import cuid_wrapper
+
+from autoblocks._impl.util import is_valid_cuid2
+
+
+@pytest.fixture
+def valid_cuid2():
+    """Generate a valid CUID2 for testing."""
+    return cuid_wrapper()()
+
+
+def test_cuid2_validation_performance(valid_cuid2):
+    """Ensure CUID2 validation doesn't become a bottleneck."""
+    # Test with valid CUID2
+    start = time.perf_counter()
+
+    for _ in range(10000):
+        is_valid_cuid2(valid_cuid2)
+
+    duration = time.perf_counter() - start
+
+    # Should validate 10k CUIDs in less than 100ms
+    assert duration < 0.1, f"Validation too slow: {duration:.3f}s for 10k validations"
+
+    # Log performance for visibility
+    print(f"Performance: {10000/duration:.0f} validations/second")
+
+
+def test_cuid2_validation_performance_invalid():
+    """Test performance with invalid CUID2s."""
+    invalid_samples = [
+        "abc123",  # too short
+        "abc123def456ghi789jkl012extra",  # too long
+        "ABC123def456ghi789jkl012",  # uppercase
+        "abc123def456ghi789jkl-12",  # special chars
+        "",  # empty
+    ]
+
+    start = time.perf_counter()
+
+    for _ in range(2000):  # 2k iterations per sample = 10k total
+        for invalid_cuid in invalid_samples:
+            is_valid_cuid2(invalid_cuid)
+
+    duration = time.perf_counter() - start
+
+    # Should validate 10k invalid CUIDs in less than 100ms
+    assert duration < 0.1, f"Invalid validation too slow: {duration:.3f}s for 10k validations"
+
+    # Log performance for visibility
+    print(f"Invalid performance: {10000/duration:.0f} validations/second")
+
+
+def test_cuid2_validation_mixed_performance(valid_cuid2):
+    """Test performance with mixed valid/invalid CUID2s."""
+    test_cases = [
+        valid_cuid2,
+        "abc123",  # invalid
+        valid_cuid2,
+        "ABC123def456ghi789jkl012",  # invalid
+        valid_cuid2,
+    ]
+
+    start = time.perf_counter()
+
+    for _ in range(2000):  # 2k iterations * 5 cases = 10k total
+        for test_case in test_cases:
+            is_valid_cuid2(test_case)
+
+    duration = time.perf_counter() - start
+
+    # Should validate 10k mixed CUIDs in less than 100ms
+    assert duration < 0.1, f"Mixed validation too slow: {duration:.3f}s for 10k validations"
+
+    # Log performance for visibility
+    print(f"Mixed performance: {10000/duration:.0f} validations/second")

--- a/tests/autoblocks/test_run_test_suite_v2_validation.py
+++ b/tests/autoblocks/test_run_test_suite_v2_validation.py
@@ -1,0 +1,298 @@
+import dataclasses
+import os
+import re
+from unittest import mock
+
+import pytest
+from cuid2 import cuid_wrapper
+
+from autoblocks._impl.util import AutoblocksEnvVar
+from autoblocks.testing.models import BaseTestCase
+from autoblocks.testing.models import BaseTestEvaluator
+from autoblocks.testing.models import Evaluation
+from autoblocks.testing.v2.run import run_test_suite
+from autoblocks.tracer import init_auto_tracer
+
+# Test data constants
+VALID_CUID2_SAMPLE = "abc123def456ghi789jkl012"
+INVALID_CUID2_SAMPLES = {
+    "too_short": "abc123",
+    "too_long": "abc123def456ghi789jkl012extra",
+    "uppercase": "ABC123def456ghi789jkl012",
+    "special_chars": "abc123def456ghi789jkl-12",
+    "empty": "",
+}
+
+
+@dataclasses.dataclass
+class MyTestCase(BaseTestCase):
+    input: str
+
+    def hash(self) -> str:
+        return self.input
+
+
+class MyEvaluator(BaseTestEvaluator):
+    id = "my-evaluator"
+
+    def evaluate_test_case(self, test_case: MyTestCase, output: str) -> Evaluation:
+        return Evaluation(score=1.0, metadata=dict(output=output))
+
+
+@pytest.fixture(autouse=True)
+def mock_env_vars():
+    """Mock environment variables needed for V2 testing."""
+    with mock.patch.dict(
+        os.environ,
+        {
+            AutoblocksEnvVar.V2_API_KEY.value: "mock-api-key",
+        },
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def init_tracer():
+    """Initialize auto tracer for V2 tests."""
+    init_auto_tracer(
+        api_key="mock-api-key",
+    )
+
+
+@pytest.fixture
+def valid_cuid2():
+    """Generate a valid CUID2 for testing."""
+    return cuid_wrapper()()
+
+
+@pytest.fixture
+def test_function():
+    """Standard test function for validation tests."""
+
+    def test_fn(test_case: MyTestCase) -> str:
+        return test_case.input + "!"
+
+    return test_fn
+
+
+def test_v2_run_id_validation_valid_cuid2(test_function):
+    """Test that run_test_suite accepts valid CUID2 run_id."""
+    # Should not raise an exception
+    run_test_suite(
+        id="my-test-id",
+        app_slug="test-app",
+        test_cases=[
+            MyTestCase(input="a"),
+        ],
+        fn=test_function,
+        evaluators=[],
+        run_id=VALID_CUID2_SAMPLE,
+    )
+
+
+def test_v2_run_id_validation_invalid_cuid2_too_short(test_function):
+    """Test that run_test_suite raises ValueError for CUID2 that's too short."""
+    invalid_run_id = INVALID_CUID2_SAMPLES["too_short"]
+
+    with pytest.raises(ValueError, match=f"Invalid run_id: '{invalid_run_id}'. Must be a valid CUID2"):
+        run_test_suite(
+            id="my-test-id",
+            app_slug="test-app",
+            test_cases=[
+                MyTestCase(input="a"),
+            ],
+            fn=test_function,
+            evaluators=[],
+            run_id=invalid_run_id,
+        )
+
+
+def test_v2_run_id_validation_invalid_cuid2_too_long():
+    """Test that run_test_suite raises ValueError for CUID2 that's too long."""
+
+    def test_fn(test_case: MyTestCase) -> str:
+        return test_case.input + "!"
+
+    # Invalid CUID2 - too long
+    invalid_run_id = "abc123def456ghi789jkl012extra"
+
+    with pytest.raises(ValueError, match="Invalid run_id: 'abc123def456ghi789jkl012extra'. Must be a valid CUID2."):
+        run_test_suite(
+            id="my-test-id",
+            app_slug="test-app",
+            test_cases=[
+                MyTestCase(input="a"),
+            ],
+            fn=test_fn,
+            evaluators=[],
+            run_id=invalid_run_id,
+        )
+
+
+def test_v2_run_id_validation_invalid_cuid2_uppercase():
+    """Test that run_test_suite raises ValueError for CUID2 with uppercase letters."""
+
+    def test_fn(test_case: MyTestCase) -> str:
+        return test_case.input + "!"
+
+    # Invalid CUID2 - contains uppercase letters
+    invalid_run_id = "ABC123def456ghi789jkl012"
+
+    with pytest.raises(ValueError, match="Invalid run_id: 'ABC123def456ghi789jkl012'. Must be a valid CUID2."):
+        run_test_suite(
+            id="my-test-id",
+            app_slug="test-app",
+            test_cases=[
+                MyTestCase(input="a"),
+            ],
+            fn=test_fn,
+            evaluators=[],
+            run_id=invalid_run_id,
+        )
+
+
+def test_v2_run_id_validation_invalid_cuid2_special_chars():
+    """Test that run_test_suite raises ValueError for CUID2 with special characters."""
+
+    def test_fn(test_case: MyTestCase) -> str:
+        return test_case.input + "!"
+
+    # Invalid CUID2 - contains special characters
+    invalid_run_id = "abc123def456ghi789jkl-12"
+
+    with pytest.raises(ValueError, match="Invalid run_id: 'abc123def456ghi789jkl-12'. Must be a valid CUID2."):
+        run_test_suite(
+            id="my-test-id",
+            app_slug="test-app",
+            test_cases=[
+                MyTestCase(input="a"),
+            ],
+            fn=test_fn,
+            evaluators=[],
+            run_id=invalid_run_id,
+        )
+
+
+def test_v2_run_id_validation_none_run_id_auto_generates():
+    """Test that run_test_suite works with None run_id (auto-generation)."""
+
+    def test_fn(test_case: MyTestCase) -> str:
+        return test_case.input + "!"
+
+    # Should not raise an exception and auto-generate a run_id
+    run_test_suite(
+        id="my-test-id",
+        app_slug="test-app",
+        test_cases=[
+            MyTestCase(input="a"),
+        ],
+        fn=test_fn,
+        evaluators=[],
+        run_id=None,  # Should auto-generate
+    )
+
+
+def test_v2_run_id_validation_empty_string(test_function):
+    """Test that run_test_suite raises ValueError for empty string run_id."""
+    invalid_run_id = INVALID_CUID2_SAMPLES["empty"]
+
+    with pytest.raises(ValueError, match=f"Invalid run_id: '{invalid_run_id}'. Must be a valid CUID2"):
+        run_test_suite(
+            id="my-test-id",
+            app_slug="test-app",
+            test_cases=[
+                MyTestCase(input="a"),
+            ],
+            fn=test_function,
+            evaluators=[],
+            run_id=invalid_run_id,
+        )
+
+
+@pytest.mark.parametrize("invalid_case", list(INVALID_CUID2_SAMPLES.keys()))
+def test_v2_run_id_validation_parametrized_invalid_cases(test_function, invalid_case):
+    """Parametrized test for all invalid CUID2 cases."""
+    invalid_run_id = INVALID_CUID2_SAMPLES[invalid_case]
+
+    with pytest.raises(ValueError, match=f"Invalid run_id: '{re.escape(invalid_run_id)}'. Must be a valid CUID2"):
+        run_test_suite(
+            id="my-test-id",
+            app_slug="test-app",
+            test_cases=[
+                MyTestCase(input="a"),
+            ],
+            fn=test_function,
+            evaluators=[],
+            run_id=invalid_run_id,
+        )
+
+
+def test_v2_run_id_validation_with_evaluators():
+    """Test that run_id validation works correctly when evaluators are present."""
+
+    def test_fn(test_case: MyTestCase) -> str:
+        return test_case.input + "!"
+
+    # Valid CUID2
+    valid_run_id = "abc123def456ghi789jkl012"
+
+    # Should not raise an exception even with evaluators
+    run_test_suite(
+        id="my-test-id",
+        app_slug="test-app",
+        test_cases=[
+            MyTestCase(input="a"),
+        ],
+        fn=test_fn,
+        evaluators=[MyEvaluator()],
+        run_id=valid_run_id,
+    )
+
+
+def test_v2_run_id_validation_with_retry_count():
+    """Test that run_id validation works correctly with retry_count parameter."""
+
+    def test_fn(test_case: MyTestCase) -> str:
+        return test_case.input + "!"
+
+    # Valid CUID2
+    valid_run_id = "abc123def456ghi789jkl012"
+
+    # Should not raise an exception even with retry_count
+    run_test_suite(
+        id="my-test-id",
+        app_slug="test-app",
+        test_cases=[
+            MyTestCase(input="a"),
+        ],
+        fn=test_fn,
+        evaluators=[],
+        run_id=valid_run_id,
+        retry_count=2,
+    )
+
+
+def test_v2_run_id_validation_happens_after_tracer_check():
+    """Test that run_id validation happens after tracer initialization check."""
+
+    def test_fn(test_case: MyTestCase) -> str:
+        return test_case.input + "!"
+
+    # Invalid CUID2
+    invalid_run_id = "invalid"
+
+    # Mock the auto tracer to not be initialized
+    with mock.patch("autoblocks._impl.global_state.is_auto_tracer_initialized", return_value=False):
+        # Should return early due to tracer not being initialized, not raise ValueError
+        # This tests that the function returns gracefully when tracer is not initialized
+        run_test_suite(
+            id="my-test-id",
+            app_slug="test-app",
+            test_cases=[
+                MyTestCase(input="a"),
+            ],
+            fn=test_fn,
+            evaluators=[],
+            run_id=invalid_run_id,
+        )
+        # If we get here without exception, the tracer check happened first

--- a/tests/autoblocks/test_run_test_suite_v2_validation.py
+++ b/tests/autoblocks/test_run_test_suite_v2_validation.py
@@ -94,7 +94,7 @@ def test_v2_run_id_validation_invalid_cuid2_too_short(test_function):
     """Test that run_test_suite raises ValueError for CUID2 that's too short."""
     invalid_run_id = INVALID_CUID2_SAMPLES["too_short"]
 
-    with pytest.raises(ValueError, match=f"Invalid run_id: '{invalid_run_id}'. Must be a valid CUID2"):
+    with pytest.raises(ValueError, match=f"Invalid run_id: '{invalid_run_id}'. Must be a valid CUID2."):
         run_test_suite(
             id="my-test-id",
             app_slug="test-app",
@@ -196,7 +196,7 @@ def test_v2_run_id_validation_empty_string(test_function):
     """Test that run_test_suite raises ValueError for empty string run_id."""
     invalid_run_id = INVALID_CUID2_SAMPLES["empty"]
 
-    with pytest.raises(ValueError, match=f"Invalid run_id: '{invalid_run_id}'. Must be a valid CUID2"):
+    with pytest.raises(ValueError, match=f"Invalid run_id: '{invalid_run_id}'. Must be a valid CUID2."):
         run_test_suite(
             id="my-test-id",
             app_slug="test-app",
@@ -214,7 +214,7 @@ def test_v2_run_id_validation_parametrized_invalid_cases(test_function, invalid_
     """Parametrized test for all invalid CUID2 cases."""
     invalid_run_id = INVALID_CUID2_SAMPLES[invalid_case]
 
-    with pytest.raises(ValueError, match=f"Invalid run_id: '{re.escape(invalid_run_id)}'. Must be a valid CUID2"):
+    with pytest.raises(ValueError, match=f"Invalid run_id: '{re.escape(invalid_run_id)}'. Must be a valid CUID2."):
         run_test_suite(
             id="my-test-id",
             app_slug="test-app",


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-11 19:26:29 UTC

This PR adds support for an optional `run_id` parameter to the v2 test suite runner, allowing users to provide their own CUID2-formatted run identifiers instead of always auto-generating them. The changes span four key areas:

**Core Implementation**: The main change is in `autoblocks/_impl/testing/v2/run.py`, where the `run_test_suite` function and its related async functions now accept an optional `run_id` parameter. When provided, the run_id is validated to ensure it's a valid CUID2 format (24 characters, lowercase letters and numbers only). If validation fails, a detailed ValueError is raised. If no run_id is provided, the system continues to auto-generate one using the existing `cuid_generator()`.

**Validation Utility**: A new `is_valid_cuid2()` function was added to `autoblocks/_impl/util.py` that efficiently validates CUID2 format using a pre-compiled regex pattern. This function includes proper type checking and is optimized for performance since it may be called frequently during test execution.

**Comprehensive Testing**: Two new test files provide extensive coverage. `test_run_test_suite_v2_validation.py` contains 12 test functions covering valid CUID2 acceptance, various invalid format rejections, None handling for auto-generation, and integration with evaluators and retry functionality. `test_cuid2_validation_performance.py` establishes performance benchmarks, ensuring 10,000 validations complete in under 100ms.

**Enhanced Tracing**: The run_id is now properly threaded through the OpenTelemetry tracing context by adding TEST_ID to baggage and span attributes, improving observability and debugging capabilities.

This change enables deterministic test run identification, which supports use cases like external system correlation, test run repeatability, debugging with consistent identifiers, and CI/CD pipeline integration where specific test execution instances need to be tracked.

## Confidence score: 4/5

- This PR introduces well-tested functionality with comprehensive validation and proper error handling
- Score reflects solid implementation with thorough testing, but complexity in validation logic requires careful attention
- Pay close attention to the CUID2 validation logic in `autoblocks/_impl/util.py` and the parameter threading in `run.py`

<!-- /greptile_comment -->