### PR TITLE
feat:Serialize human review fields not respected in V2

### DIFF
--- a/autoblocks/_impl/testing/v2/api.py
+++ b/autoblocks/_impl/testing/v2/api.py
@@ -157,6 +157,8 @@ async def send_create_result(
     evaluator_id_to_reason: dict[str, str],
     evaluator_id_to_score: dict[str, float],
     run_message: Optional[str] = None,
+    input_human_review_fields: Optional[List[dict[str, Any]]] = None,
+    output_human_review_fields: Optional[List[dict[str, Any]]] = None,
 ) -> Response:
     return await post_to_api(
         "/testing/results",
@@ -175,5 +177,7 @@ async def send_create_result(
             evaluatorIdToResult=evaluator_id_to_result,
             evaluatorIdToReason=evaluator_id_to_reason,
             evaluatorIdToScore=evaluator_id_to_score,
+            inputHumanReviewFields=input_human_review_fields,
+            outputHumanReviewFields=output_human_review_fields,
         ),
     )

--- a/autoblocks/_impl/testing/v2/run_manager.py
+++ b/autoblocks/_impl/testing/v2/run_manager.py
@@ -13,7 +13,9 @@ from autoblocks._impl.testing.models import Evaluation
 from autoblocks._impl.testing.models import EvaluationWithId
 from autoblocks._impl.testing.models import TestCaseContext
 from autoblocks._impl.testing.util import serialize_output
+from autoblocks._impl.testing.util import serialize_output_for_human_review
 from autoblocks._impl.testing.util import serialize_test_case
+from autoblocks._impl.testing.util import serialize_test_case_for_human_review
 from autoblocks._impl.testing.v2.api import send_create_human_review_job
 from autoblocks._impl.testing.v2.api import send_create_result
 from autoblocks._impl.testing.v2.run import evaluator_semaphore_registry
@@ -168,6 +170,10 @@ class RunManager:
         input_raw = json.dumps(serialize_test_case(test_case))
         output_raw = json.dumps(serialize_output(output))
 
+        # Serialize human review fields
+        input_human_review_fields = serialize_test_case_for_human_review(test_case)
+        output_human_review_fields = serialize_output_for_human_review(output)
+
         # Per-execution start time defaults to now if not provided
         exec_started_at = started_at or now_rfc3339()
 
@@ -187,6 +193,8 @@ class RunManager:
             evaluator_id_to_reason=eval_reason_map,
             evaluator_id_to_score=eval_score_map,
             run_message=self.run_message,
+            input_human_review_fields=input_human_review_fields,
+            output_human_review_fields=output_human_review_fields,
         )
         data = resp.json()
         execution_id = data["executionId"]

--- a/tests/autoblocks/test_run_manager_v2.py
+++ b/tests/autoblocks/test_run_manager_v2.py
@@ -51,6 +51,19 @@ class MyOutput:
         return [HumanReviewField(name="output", value=self.output, content_type=HumanReviewFieldContentType.TEXT)]
 
 
+@dataclass
+class NoHumanReviewTestCase(BaseTestCase):
+    input: str
+
+    def hash(self) -> str:
+        return self.input
+
+
+@dataclass
+class NoHumanReviewOutput:
+    output: str
+
+
 class MyEvaluator(BaseTestEvaluator):
     @property
     def id(self) -> str:
@@ -94,6 +107,8 @@ def test_full_lifecycle_v2(httpx_mock):
             evaluatorIdToResult={"evaluator-external-id": True},
             evaluatorIdToReason={"evaluator-external-id": "ok"},
             evaluatorIdToScore={"evaluator-external-id": 1},
+            inputHumanReviewFields=[{"name": "input", "value": "test", "contentType": "text"}],
+            outputHumanReviewFields=[{"name": "output", "value": "test", "contentType": "text"}],
         ),
         json=dict(executionId="mock-exec-id"),
     )
@@ -180,6 +195,8 @@ def test_add_result_without_evaluators_sends_empty_maps(httpx_mock):
             evaluatorIdToResult={},
             evaluatorIdToReason={},
             evaluatorIdToScore={},
+            inputHumanReviewFields=[{"name": "input", "value": "test", "contentType": "text"}],
+            outputHumanReviewFields=[{"name": "output", "value": "test", "contentType": "text"}],
         ),
         json=dict(executionId="exec-1"),
     )
@@ -192,3 +209,40 @@ def test_add_result_without_evaluators_sends_empty_maps(httpx_mock):
         duration_ms=250,
     )
     assert exec_id == "exec-1"
+
+
+def test_add_result_without_custom_human_review_fields(httpx_mock):
+    """Test that when test case/output don't define serialize_for_human_review,
+    inputHumanReviewFields and outputHumanReviewFields are sent as None."""
+    httpx_mock.add_response(
+        url=f"{API_ENDPOINT_V2}/testing/results",
+        method="POST",
+        match_json=dict(
+            appSlug="my-app",
+            runId=ANY_STRING,
+            environment="test",
+            runMessage=None,
+            startedAt=ANY_STRING,
+            durationMS=100,
+            status="SUCCESS",
+            inputRaw=json.dumps({"input": "test"}),
+            outputRaw=json.dumps({"output": "test"}),
+            input={"input": "test"},
+            output={"output": "test"},
+            evaluatorIdToResult={},
+            evaluatorIdToReason={},
+            evaluatorIdToScore={},
+            inputHumanReviewFields=None,
+            outputHumanReviewFields=None,
+        ),
+        json=dict(executionId="exec-2"),
+    )
+
+    test_run = RunManager(app_slug="my-app")
+    test_run.start()
+    exec_id = test_run.add_result(
+        test_case=NoHumanReviewTestCase(input="test"),
+        output=NoHumanReviewOutput(output="test"),
+        duration_ms=100,
+    )
+    assert exec_id == "exec-2"


### PR DESCRIPTION
Description:
In V2 of the Python SDK, when creating a Human Review job, all object attributes are being serialized instead of only those explicitly defined in serialize_for_human_review(). This causes non-relevant fields (e.g., org_id, expected_latency, file_groups, source) to appear in the Human Review interface.

In V1, only the specified fields are correctly serialized. V2 seems to ignore or skip the serialize_for_human_review() logic.
Only the fields defined in serialize_for_human_review() (e.g., Query, Reference Answer) should be included in the payload for Human Review.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-09 11:44:10 UTC

<h3>Summary</h3>
This PR addresses a bug (EPD-2242) where human review field serialization wasn't working correctly in the V2 testing framework. The changes bring feature parity between V1 and V2 testing APIs by adding proper support for the `serialize_for_human_review()` method in test cases and outputs.

The implementation involves three key components: First, the V2 run manager now imports and uses the existing `serialize_test_case_for_human_review` and `serialize_output_for_human_review` utility functions to extract human review fields from test cases and outputs. Second, the V2 API client's `send_create_result` function is updated to accept and forward these fields as optional parameters. Finally, comprehensive tests are added to verify both scenarios - when objects implement the serialization method (fields are sent) and when they don't (None values are sent).

This change integrates seamlessly with the existing codebase by reusing the serialization utilities already established in V1, maintaining the same optional behavior where human review fields can be None if objects don't implement the `serialize_for_human_review()` method. The implementation follows established patterns in the codebase and ensures backward compatibility while extending functionality.
<h3>Important Files Changed</h3>

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `autoblocks/_impl/testing/v2/run_manager.py` | 5/5 | Adds human review field serialization by importing utility functions and passing serialized fields to the API |
| `autoblocks/_impl/testing/v2/api.py` | 5/5 | Extends `send_create_result` function with optional human review field parameters and includes them in the API payload |
| `tests/autoblocks/test_run_manager_v2.py` | 5/5 | Adds comprehensive test coverage including new test classes without serialization methods and verification of None values |

</details>
<h3>Confidence score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects well-tested changes that follow established patterns and maintain backward compatibility
- No files require special attention as all changes are straightforward and properly tested

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant RunManager
    participant GlobalState
    participant API
    participant TestCaseContext
    participant Evaluators
    participant HttpClient
    
    User->>RunManager: create RunManager(app_slug, environment, run_message)
    User->>RunManager: start()
    RunManager->>GlobalState: init()
    RunManager->>RunManager: set started_at timestamp
    
    User->>RunManager: add_result(test_case, output, duration_ms, evaluators)
    RunManager->>TestCaseContext: create TestCaseContext(test_case)
    RunManager->>RunManager: _compute_evaluations()
    RunManager->>Evaluators: run_evaluator() for each evaluator
    Evaluators-->>RunManager: return EvaluationWithId results
    RunManager->>RunManager: _evaluations_to_maps()
    RunManager->>RunManager: serialize test case and output
    RunManager->>RunManager: serialize_test_case_for_human_review()
    RunManager->>RunManager: serialize_output_for_human_review()
    RunManager->>API: send_create_result()
    API->>HttpClient: POST /testing/results
    HttpClient-->>API: response with executionId
    API-->>RunManager: response
    RunManager-->>User: return execution_id
    
    User->>RunManager: end()
    RunManager->>RunManager: set ended_at timestamp
    RunManager->>RunManager: set can_create_human_review = True
    
    User->>RunManager: create_human_review(name, assignee_emails, rubric_id)
    RunManager->>API: send_create_human_review_job()
    API->>HttpClient: POST /apps/{app_slug}/human-review/jobs
    HttpClient-->>API: response
    API-->>RunManager: response
    RunManager-->>User: complete
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->